### PR TITLE
ci(runners): move the Intel macOS job off the retired `macos-13` label

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -56,7 +56,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-13
+          - os: macos-15-intel
             target: x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin


### PR DESCRIPTION
The `1.2.0` release never reached PyPI, and this is why.

`macos-13` was fully retired on December 8th, 2025
(https://github.com/actions/runner-images/issues/13046). A job asking for that
label is not rejected — it sits in `queued` waiting for a runner that will never
arrive. The tag run for `1.2.0` shows exactly that: every other job finished
successfully and `macos (macos-13, x86_64-apple-darwin)` is still queued,
so `release` never starts, because it needs the whole `macos` matrix.

The announcement names `macos-15-intel` as the replacement label, and that is
what this changes to. It is a standard runner, free on public repositories, and
GitHub has said it is the last x86_64 image, available until August 2027. When
that date approaches the choice is either `x86_64-apple-darwin` cross-compiled
on an arm64 runner or dropping the Intel wheel — but that is a decision for
later, not something to settle while a release is stuck.

Nothing else changes. After merging, the `1.2.0` tag needs re-running for the
release job to pick it up.
