### PR TITLE
fix(recognizer): accept any `os.PathLike` in `recognize_path`

### DIFF
--- a/src/fingerprinting/algorithm.rs
+++ b/src/fingerprinting/algorithm.rs
@@ -7,6 +7,7 @@ use rodio::{ChannelCount, Sample, SampleRate, Source};
 use std::collections::HashMap;
 use std::error::Error;
 use std::io::{BufReader, Cursor};
+use std::path::Path;
 use std::time::Duration;
 
 // The fingerprint is defined over mono 16 kHz PCM; every input is resampled to
@@ -132,7 +133,7 @@ impl SignatureGenerator {
         // Return the generated signature
         Ok(signature)
     }
-    pub fn make_signature_from_file(file_path: &str, segment_duration_seconds: Option<u32>) -> Result<DecodedSignature, Box<dyn Error>> {
+    pub fn make_signature_from_file(file_path: &Path, segment_duration_seconds: Option<u32>) -> Result<DecodedSignature, Box<dyn Error>> {
         // Decode the .WAV, .MP3, .OGG or .FLAC file
 
         let mut decoder = rodio::Decoder::new(BufReader::new(std::fs::File::open(file_path)?));

--- a/src/fingerprinting/ffmpeg_wrapper.rs
+++ b/src/fingerprinting/ffmpeg_wrapper.rs
@@ -2,7 +2,7 @@ use std::error::Error;
 use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{BufReader, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
@@ -19,21 +19,22 @@ use tempfile::Builder;
 pub fn decode_with_ffmpeg(file_path: &Path) -> Option<Decoder<BufReader<File>>> {
     // Find the path for FFMpeg, in the case where it is installed
 
-    let mut possible_ffmpeg_paths: Vec<&str> = vec!["ffmpeg", "ffmpeg.exe"];
+    let mut possible_ffmpeg_paths: Vec<PathBuf> =
+        vec![PathBuf::from("ffmpeg"), PathBuf::from("ffmpeg.exe")];
 
     let mut current_dir_ffmpeg_path =
         std::env::current_exe().expect("failed current_dir_ffmpeg_path");
     current_dir_ffmpeg_path.pop();
     current_dir_ffmpeg_path.push("ffmpeg.exe");
-    possible_ffmpeg_paths.push(current_dir_ffmpeg_path.to_str().unwrap());
-    let mut actual_ffmpeg_path: Option<&str> = None;
+    possible_ffmpeg_paths.push(current_dir_ffmpeg_path);
+    let mut actual_ffmpeg_path: Option<PathBuf> = None;
 
     for possible_path in possible_ffmpeg_paths {
         // Use .output() to execute the subprocess testing for FFMpeg
         // presence and correct execution, so that it does not pollute
         // the standard or error output in any way
 
-        let mut command = Command::new(possible_path);
+        let mut command = Command::new(&possible_path);
         #[cfg(windows)]
         let command = command.creation_flags(0x08000000);
         let command = command.arg("-version");
@@ -81,10 +82,8 @@ pub fn decode_with_ffmpeg(file_path: &Path) -> Option<Decoder<BufReader<File>>> 
 
         if let Ok(process) = command.output() {
             if process.status.success() {
-                let res = Decoder::new(BufReader::new(
-                    File::open(sink_file_path.to_str().unwrap()).unwrap(),
-                ))
-                .expect("failed to decode with ffmpeg");
+                let res = Decoder::new(BufReader::new(File::open(&sink_file_path).unwrap()))
+                    .expect("failed to decode with ffmpeg");
                 return Some(res);
             }
         } else {
@@ -100,26 +99,27 @@ pub fn decode_with_ffmpeg_from_bytes(
     // Create a temporary file for the input
     let mut temp_file = Builder::new().suffix(".tmp").tempfile()?;
     temp_file.write_all(bytes)?;
-    let file_path = temp_file.path().to_str().unwrap().to_string();
+    let file_path = temp_file.path().to_path_buf();
 
     // Find the FFmpeg path
-    let mut possible_ffmpeg_paths = vec!["ffmpeg", "ffmpeg.exe"];
+    let mut possible_ffmpeg_paths: Vec<PathBuf> =
+        vec![PathBuf::from("ffmpeg"), PathBuf::from("ffmpeg.exe")];
     let mut current_dir_ffmpeg_path =
         std::env::current_exe().expect("failed current_dir_ffmpeg_path");
     current_dir_ffmpeg_path.pop();
     current_dir_ffmpeg_path.push("ffmpeg.exe");
-    possible_ffmpeg_paths.push(current_dir_ffmpeg_path.to_str().unwrap());
+    possible_ffmpeg_paths.push(current_dir_ffmpeg_path);
 
-    let mut actual_ffmpeg_path = None;
-    for possible_path in &possible_ffmpeg_paths {
-        let mut command = Command::new(possible_path);
+    let mut actual_ffmpeg_path: Option<PathBuf> = None;
+    for possible_path in possible_ffmpeg_paths {
+        let mut command = Command::new(&possible_path);
         #[cfg(windows)]
         let command = command.creation_flags(0x08000000);
         let command = command.arg("-version");
 
         if let Ok(process) = command.output() {
             if process.status.success() {
-                actual_ffmpeg_path = Some(*possible_path);
+                actual_ffmpeg_path = Some(possible_path);
                 break;
             }
         }
@@ -128,18 +128,25 @@ pub fn decode_with_ffmpeg_from_bytes(
     if let Some(ffmpeg_path) = actual_ffmpeg_path {
         // Create a temporary file for the output
         let sink_file = Builder::new().suffix(".wav").tempfile()?;
-        let sink_file_path = sink_file.path().to_str().unwrap().to_string();
+        let sink_file_path = sink_file.path().to_path_buf();
 
         // Convert to WAV format
         let mut command = Command::new(ffmpeg_path);
         #[cfg(windows)]
         let command = command.creation_flags(0x08000000);
-        let command = command.args(["-y", "-i", &file_path, &sink_file_path]);
+        // Same as above: one array, one element type, and no path forced through
+        //  `&str`.
+        let command = command.args([
+            OsStr::new("-y"),
+            OsStr::new("-i"),
+            file_path.as_os_str(),
+            sink_file_path.as_os_str(),
+        ]);
 
         if let Ok(process) = command.output() {
             if process.status.success() {
                 // Read the converted file into a Vec<u8>
-                let converted_bytes = std::fs::read(sink_file_path)?;
+                let converted_bytes = std::fs::read(&sink_file_path)?;
 
                 // Create a Cursor around the converted bytes and create a Decoder
                 let cursor = Cursor::new(converted_bytes);

--- a/src/fingerprinting/ffmpeg_wrapper.rs
+++ b/src/fingerprinting/ffmpeg_wrapper.rs
@@ -1,6 +1,8 @@
 use std::error::Error;
+use std::ffi::OsStr;
 use std::fs::File;
 use std::io::{BufReader, Write};
+use std::path::Path;
 
 #[cfg(windows)]
 use std::os::windows::process::CommandExt;
@@ -14,7 +16,7 @@ use tempfile::Builder;
 /// the system, in the case where Rodio can't decode the concerned format
 /// (for example with .WMA, .M4A, etc.).
 
-pub fn decode_with_ffmpeg(file_path: &str) -> Option<Decoder<BufReader<File>>> {
+pub fn decode_with_ffmpeg(file_path: &Path) -> Option<Decoder<BufReader<File>>> {
     // Find the path for FFMpeg, in the case where it is installed
 
     let mut possible_ffmpeg_paths: Vec<&str> = vec!["ffmpeg", "ffmpeg.exe"];
@@ -64,7 +66,15 @@ pub fn decode_with_ffmpeg(file_path: &str) -> Option<Decoder<BufReader<File>>> {
         #[cfg(windows)]
         let command = command.creation_flags(0x08000000);
 
-        let command = command.args(["-y", "-i", file_path, sink_file_path.to_str().unwrap()]);
+        // One array, one element type: the two paths are `OsStr`, so the flags are
+        //  spelled that way too rather than converting the paths to `&str`, which
+        //  would fail on any path that is not valid UTF-8.
+        let command = command.args([
+            OsStr::new("-y"),
+            OsStr::new("-i"),
+            file_path.as_os_str(),
+            sink_file_path.as_os_str(),
+        ]);
 
         // Set "CREATE_NO_WINDOW" on Windows, see
         // https://stackoverflow.com/a/60958956/662399

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,7 @@ use crate::utils::get_python_future;
 use crate::utils::unwrap_decoded_signature;
 use fingerprinting::algorithm::SignatureGenerator;
 use pyo3::prelude::*;
+use std::path::PathBuf;
 use pyo3::{pyclass, pymethods, pymodule, Bound, Py, PyAny, PyErr, PyResult, Python};
 use pyo3::types::PyModule;
 use log::{info, debug, error};
@@ -95,12 +96,12 @@ impl Recognizer {
     fn recognize_path(
         &self,
         py: Python,
-        value: String,
+        value: PathBuf,
         options: Option<SearchParams>,
     ) -> PyResult<Py<PyAny>> {
         debug!(
             "recognize_path method called with path: {} and options: {:?}",
-            value,
+            value.display(),
             options,
         );
 
@@ -113,7 +114,7 @@ impl Recognizer {
         });
 
         let future = async move {
-            debug!("Starting async recognition from file: {}", value);
+            debug!("Starting async recognition from file: {}", value.display());
             let data = SignatureGenerator::make_signature_from_file(
                 &value,
                 Some(search_options.segment_duration_seconds),

--- a/tests/test_recognizer.py
+++ b/tests/test_recognizer.py
@@ -40,18 +40,13 @@ EXPECTED_DURATION_MS: Final[int] = 8000
 
 
 def _probe(audio_format: str) -> Path:
-    # Callers wrap this in `str()`: `recognize_path` extracts a Rust `String` and
-    #  rejects a `Path` with `TypeError: 'PosixPath' object is not an instance of
-    #  'str'`, even though `shazamio_core/shazamio_core.pyi:80` declares
-    #  `Union[str, PathLike]`. It still returns a `Path` -- `recognize_bytes` needs
-    #  `.read_bytes()`.
     return DATA_DIRECTORY / f"probe.{audio_format}"
 
 
 async def test_the_flac_signature_matches_the_golden_uri(*, recognizer: Recognizer) -> None:
     golden_uri = (DATA_DIRECTORY / f"probe.{LOSSLESS_AUDIO_FORMAT}.uri").read_text().strip()
 
-    signature = await recognizer.recognize_path(str(_probe(LOSSLESS_AUDIO_FORMAT)))
+    signature = await recognizer.recognize_path(_probe(LOSSLESS_AUDIO_FORMAT))
 
     assert signature.signature.uri == golden_uri
 
@@ -65,7 +60,7 @@ async def test_recognize_bytes_matches_recognize_path(
     audio = _probe(audio_format)
 
     from_bytes = await recognizer.recognize_bytes(audio.read_bytes())
-    from_path = await recognizer.recognize_path(str(audio))
+    from_path = await recognizer.recognize_path(audio)
 
     assert from_bytes.signature.uri == from_path.signature.uri
 
@@ -76,6 +71,19 @@ async def test_every_format_decodes_the_whole_file(
     *,
     recognizer: Recognizer,
 ) -> None:
-    signature = await recognizer.recognize_path(str(_probe(audio_format)))
+    signature = await recognizer.recognize_path(_probe(audio_format))
 
     assert signature.signature.samples == EXPECTED_DURATION_MS
+
+
+async def test_recognize_path_accepts_a_string_too(*, recognizer: Recognizer) -> None:
+    # The tests above pass a `Path`. `recognize_path` extracts a Rust `PathBuf`
+    #  through `os.fspath`, so both forms are accepted; before that it extracted a
+    #  `String` and rejected a `Path` with `TypeError: 'PosixPath' object is not an
+    #  instance of 'str'`, contradicting its own type stub.
+    audio = _probe("mp3")
+
+    from_string = await recognizer.recognize_path(str(audio))
+    from_path = await recognizer.recognize_path(audio)
+
+    assert from_string.signature.uri == from_path.signature.uri

--- a/tests/test_recognizer.py
+++ b/tests/test_recognizer.py
@@ -15,12 +15,14 @@ That is decoder arithmetic, not something a golden file can pin. The two lossy
 formats keep the checks below, which hold on every platform.
 """
 
+import os
+import sys
 from pathlib import Path
 from typing import Final
 
 import pytest
 
-from shazamio_core import Recognizer
+from shazamio_core import Recognizer, SignatureError
 
 DATA_DIRECTORY: Final[Path] = Path(__file__).parent / "data"
 
@@ -87,3 +89,26 @@ async def test_recognize_path_accepts_a_string_too(*, recognizer: Recognizer) ->
     from_path = await recognizer.recognize_path(audio)
 
     assert from_string.signature.uri == from_path.signature.uri
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="only Linux lets a directory name be invalid UTF-8",
+)
+async def test_a_temp_directory_that_is_not_utf8_raises_instead_of_panicking(
+    tmp_path: Path,
+    *,
+    recognizer: Recognizer,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The ffmpeg fallback builds its scratch paths under `TMPDIR`. Those paths used to
+    #  be forced through `str`, so a directory Linux allows and UTF-8 does not aborted
+    #  the tokio worker with `pyo3_async_runtimes.RustPanic: rust future panicked`,
+    #  which no `except SignatureError` around the call can catch.
+    broken_tmpdir = tmp_path / os.fsdecode(b"\xff")
+    broken_tmpdir.mkdir()
+    monkeypatch.setenv("TMPDIR", str(broken_tmpdir))
+
+    # Not decodable by `rodio`, so the call reaches the ffmpeg fallback.
+    with pytest.raises(SignatureError):
+        await recognizer.recognize_bytes(b"\x00" * 4096)


### PR DESCRIPTION
## What

Two commits:

1. `recognize_path` accepts any `os.PathLike`, not only `str`.
2. The ffmpeg fallback stops forcing paths through `&str`, so a temp directory whose name is not valid UTF-8 raises instead of aborting the worker.

## Why

The type stub already promised the first one. `shazamio_core/shazamio_core.pyi` declares

```python
async def recognize_path(self, value: Union[str, PathLike], ...) -> Signature
```

while the implementation extracted a Rust `String`, which pyo3 fills from a real `str` and nothing else. Passing the annotated type therefore type-checked and then failed at runtime:

```
>>> await Recognizer().recognize_path(Path("song.mp3"))
TypeError: 'PosixPath' object is not an instance of 'str'
```

Fixing the signature rather than the stub, because the stub describes the API we want.

The second one is what the first one uncovered. `src/fingerprinting/ffmpeg_wrapper.rs` called `to_str().unwrap()` on five paths, three of which it builds itself under `TMPDIR`. A directory name Linux allows and UTF-8 does not therefore panicked inside the tokio worker:

```
thread 'tokio-runtime-worker' panicked at src/utils.rs:20:14:
called `Result::unwrap()` on an `Err` value: JoinError::Panic(..., "called `Option::unwrap()` on a `None` value")
pyo3_async_runtimes.RustPanic: rust future panicked: unknown error
```

`RustPanic` is not a subclass of `SignatureError`, so no handler a caller could reasonably write catches it. After the change the same input raises `SignatureError: FFmpeg not found or failed to convert audio`.

## How

`value: String` becomes `value: PathBuf`. pyo3 extracts `PathBuf` through `os.fspath`, so `str`, `Path` and anything else implementing the protocol all work.

The path then travels as `&Path` through `make_signature_from_file` and into `decode_with_ffmpeg`. Inside the wrapper the ffmpeg candidate list, the scratch files and the arguments handed to `Command` are all `PathBuf` / `OsStr`; no path is converted to `&str` anywhere any more.

## Tests

Every existing test now passes a `Path` directly, so they are the `os.PathLike` coverage, and one test asserts that the `str` and `Path` forms of the same file produce the same signature. The panic has its own Linux-only test, which sets `TMPDIR` to a directory named `b"\xff"` and asserts `SignatureError`.

Run against `src/` before this change, the whole suite fails:

```
9 failed in 0.15s
```

## How to test

```
pip install . pytest pytest-asyncio
pytest
```

