### PR TITLE
test(fingerprint): unit-test the signature format and the Python bindings

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,6 +58,18 @@ jobs:
       - name: Run the tests
         run: pytest
 
+  # The Rust side has no interpreter in it: byte layout, checksum, band ordering.
+  # None of that varies by platform, so one runner answers for all of them --
+  # whether the fingerprint itself does is what the job above exists for.
+  rust-test:
+    name: Rust unit tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Run the unit tests
+        run: cargo test
+
   # The wheels below are abi3: one per platform, loading on every CPython from 3.9
   # up. There is no per-interpreter matrix any more, so a new CPython release
   # needs no change here and no new release.
@@ -224,7 +236,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'"
-    needs: [ test, sdist, macos, linux, windows ]
+    needs: [ test, rust-test, sdist, macos, linux, windows ]
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -58,14 +58,22 @@ jobs:
       - name: Run the tests
         run: pytest
 
-  # The Rust side has no interpreter in it: byte layout, checksum, band ordering.
-  # None of that varies by platform, so one runner answers for all of them --
-  # whether the fingerprint itself does is what the job above exists for.
+  # Byte layout, checksum, band ordering: none of that varies by platform, so one
+  #  runner answers for all of them -- whether the fingerprint itself does is what
+  #  the job above exists for.
   rust-test:
     name: Rust unit tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The test binary is an executable rather than an extension module, so it
+      #  links `libpython` instead of borrowing the loader's symbols, and needs an
+      #  interpreter built `--enable-shared` -- which is what this action ships.
+      #  https://github.com/actions/python-versions/blob/c2033aa6c313f068f4bde238bfaa5987ad4f2e79/builders/ubuntu-python-builder.psm1#L37
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.x"
 
       - name: Run the unit tests
         run: cargo test

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,5 +39,3 @@ pyo3-async-runtimes = { version = "0.29.0", features = ["tokio-runtime"] }
 pyo3-log = "=0.13.4"
 log = "0.4.33"
 
-[features]
-default = ["pyo3/extension-module"]

--- a/docker/Dockerfile.manylinux_2_28_ARM64
+++ b/docker/Dockerfile.manylinux_2_28_ARM64
@@ -32,7 +32,11 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 WORKDIR /opt
 COPY --from=planner /opt/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+# `cargo chef` runs plain `cargo` before `maturin` is ever invoked, so nothing turns
+#  extension-module linking on for it, and no interpreter in this image ships a
+#  `libpython` -- the step died on `could not find native static library python3.9`.
+#  Why the feature went away: the `[build-system]` comment in `pyproject.toml`.
+RUN PYO3_BUILD_EXTENSION_MODULE=1 cargo chef cook --release --recipe-path recipe.json
 COPY . .
 ARG PYTHON_INTERPRETER
 RUN bash /opt/docker/build-manylinux.sh

--- a/docker/Dockerfile.manylinux_2_28_X64
+++ b/docker/Dockerfile.manylinux_2_28_X64
@@ -32,7 +32,11 @@ RUN cargo chef prepare --recipe-path recipe.json
 FROM chef AS builder
 WORKDIR /opt
 COPY --from=planner /opt/recipe.json recipe.json
-RUN cargo chef cook --release --recipe-path recipe.json
+# `cargo chef` runs plain `cargo` before `maturin` is ever invoked, so nothing turns
+#  extension-module linking on for it, and no interpreter in this image ships a
+#  `libpython` -- the step died on `could not find native static library python3.9`.
+#  Why the feature went away: the `[build-system]` comment in `pyproject.toml`.
+RUN PYO3_BUILD_EXTENSION_MODULE=1 cargo chef cook --release --recipe-path recipe.json
 COPY . .
 ARG PYTHON_INTERPRETER
 RUN bash /opt/docker/build-manylinux.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,12 +2,17 @@
 package-mode = false
 
 [tool.poetry.group.dev.dependencies]
-maturin = "^1.8.1"
+# Canonical floor: `build-system.requires` below.
+maturin = "^1.9.4"
 pytest = "^8.3.4"
 pytest-asyncio = "^1.2.0"
 
 [build-system]
-requires = ["maturin>=1.4.0"]
+# `pyo3/extension-module` is deprecated and this crate no longer enables it: the
+#  feature dropped the link to `libpython`, which broke `cargo test`. `maturin`
+#  1.9.4 is the first release that turns extension-module linking on by itself.
+#  https://pyo3.rs/v0.29.0/faq.html#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror
+requires = ["maturin>=1.9.4"]
 build-backend = "maturin"
 
 [project]

--- a/src/fingerprinting/algorithm.rs
+++ b/src/fingerprinting/algorithm.rs
@@ -381,3 +381,175 @@ impl SignatureGenerator {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The probe and its pinned URI are the ones `tests/` uses; `tests/data/generate.sh`
+    //  regenerates the audio. Reading them here rather than restating the expected
+    //  bytes keeps one copy of the golden.
+    const DATA_DIRECTORY: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data");
+
+    fn probe_path() -> String {
+        format!("{DATA_DIRECTORY}/probe.flac")
+    }
+
+    fn golden_uri() -> String {
+        std::fs::read_to_string(format!("{DATA_DIRECTORY}/probe.flac.uri"))
+            .unwrap()
+            .trim()
+            .to_string()
+    }
+
+    // Yields nothing: every test here asks about `current_span_len`, which the
+    //  resampler reads before it takes a single sample.
+    struct FixedSpan {
+        span_length: Option<usize>,
+    }
+
+    impl Iterator for FixedSpan {
+        type Item = Sample;
+
+        fn next(&mut self) -> Option<Self::Item> {
+            None
+        }
+    }
+
+    impl Source for FixedSpan {
+        fn current_span_len(&self) -> Option<usize> {
+            self.span_length
+        }
+
+        fn channels(&self) -> ChannelCount {
+            TARGET_CHANNELS
+        }
+
+        fn sample_rate(&self) -> SampleRate {
+            TARGET_SAMPLE_RATE
+        }
+
+        fn total_duration(&self) -> Option<Duration> {
+            None
+        }
+    }
+
+    #[test]
+    fn a_zero_length_span_is_reported_as_unbounded() {
+        let mut source = NonEmptySpans(FixedSpan {
+            span_length: Some(0),
+        });
+
+        assert_eq!(source.current_span_len(), None);
+        assert_eq!(source.next(), None);
+    }
+
+    #[test]
+    fn every_other_span_passes_through_untouched() {
+        for span_length in [Some(1), Some(94), Some(1152), None] {
+            let source = NonEmptySpans(FixedSpan { span_length });
+
+            assert_eq!(source.current_span_len(), span_length);
+        }
+    }
+
+    #[test]
+    fn the_wrapper_reports_the_channels_and_rate_of_what_it_wraps() {
+        let source = NonEmptySpans(FixedSpan {
+            span_length: Some(1),
+        });
+
+        assert_eq!(source.channels(), TARGET_CHANNELS);
+        assert_eq!(source.sample_rate(), TARGET_SAMPLE_RATE);
+        assert_eq!(source.total_duration(), None);
+    }
+
+    #[test]
+    fn the_whole_pipeline_reproduces_the_golden_uri() {
+        let signature = SignatureGenerator::make_signature_from_file(&probe_path(), None).unwrap();
+
+        // The probe is 8 s, so the default 10 s segment takes all of it and the peaks
+        //  below are every peak the file has.
+        assert_eq!(signature.number_samples, 128013);
+        assert_eq!(signature.encode_to_uri().unwrap(), golden_uri());
+
+        // Peaks landed in every band, so `do_peak_recognition` ran its whole match.
+        let mut bands: Vec<_> = signature.frequency_band_to_sound_peaks.keys().collect();
+        bands.sort();
+        assert_eq!(
+            bands,
+            vec![
+                &FrequencyBand::_250_520,
+                &FrequencyBand::_520_1450,
+                &FrequencyBand::_1450_3500,
+                &FrequencyBand::_3500_5500,
+            ],
+        );
+    }
+
+    #[test]
+    fn a_segment_shorter_than_the_file_is_cut_from_the_middle() {
+        let from_file =
+            SignatureGenerator::make_signature_from_file(&probe_path(), Some(4)).unwrap();
+        let from_bytes = SignatureGenerator::make_signature_from_bytes(
+            std::fs::read(probe_path()).unwrap(),
+            Some(4),
+        )
+        .unwrap();
+
+        assert_eq!(from_file.number_samples, 4 * 16000);
+
+        // Both entry points cut the same window, so they fingerprint the same audio.
+        assert_eq!(
+            from_bytes.encode_to_uri().unwrap(),
+            from_file.encode_to_uri().unwrap(),
+        );
+    }
+
+    #[test]
+    fn the_bytes_of_a_file_fingerprint_the_same_as_its_path() {
+        let probe = std::fs::read(probe_path()).unwrap();
+
+        let from_bytes = SignatureGenerator::make_signature_from_bytes(probe, None).unwrap();
+
+        assert_eq!(from_bytes.encode_to_uri().unwrap(), golden_uri());
+    }
+
+    // Both entry points fall back to `ffmpeg` when `rodio` cannot read the input, and
+    //  `ffmpeg` cannot read this either -- present or not, the answer is an error and
+    //  never a panic or an empty signature.
+    #[test]
+    fn input_no_decoder_understands_is_an_error() {
+        let not_audio = SignatureGenerator::make_signature_from_bytes(b"not audio".to_vec(), None);
+        let script = format!("{DATA_DIRECTORY}/generate.sh");
+        let not_a_sound_file = SignatureGenerator::make_signature_from_file(&script, None);
+
+        assert!(not_audio.is_err());
+        assert!(not_a_sound_file.is_err());
+    }
+
+    #[test]
+    fn a_seek_is_handed_to_the_wrapped_source() {
+        let mut source = NonEmptySpans(FixedSpan {
+            span_length: Some(1),
+        });
+
+        // `FixedSpan` does not override `try_seek`, so this is `Source`'s own refusal
+        //  arriving through the wrapper rather than being answered by it.
+        assert!(source.try_seek(Duration::ZERO).is_err());
+    }
+
+    #[test]
+    fn samples_are_scaled_to_i16_and_saturate_instead_of_wrapping() {
+        assert_eq!(to_i16(0.0), 0);
+        assert_eq!(to_i16(-1.0), -32768);
+
+        // `1.0 * 32_768.0` is one past `i16::MAX`; a float-to-int cast saturates, so
+        //  full scale comes out as the largest sample rather than the smallest.
+        assert_eq!(to_i16(1.0), 32767);
+
+        // Anything beyond full scale is clamped first, so it lands on the same value.
+        assert_eq!(to_i16(4.0), 32767);
+        assert_eq!(to_i16(-4.0), -32768);
+    }
+}

--- a/src/fingerprinting/communication.rs
+++ b/src/fingerprinting/communication.rs
@@ -46,3 +46,32 @@ pub fn get_signature_json(signature: &DecodedSignature) -> Result<Signature, Box
         timezone: "Europe/Paris".to_string(),
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    #[test]
+    fn the_sample_count_is_reported_as_a_duration_in_milliseconds() {
+        let decoded = DecodedSignature {
+            sample_rate_hz: 16000,
+            number_samples: 24_500,
+            frequency_band_to_sound_peaks: HashMap::new(),
+        };
+        let expected_uri = decoded.encode_to_uri().unwrap();
+
+        let signature = get_signature_json(&decoded).unwrap();
+
+        // `samples` names a duration, not a count: the sample count over the sample
+        //  rate, truncated to whole milliseconds.
+        assert_eq!(signature.signature.samples, 1531);
+
+        assert_eq!(signature.timestamp, signature.signature.timestamp);
+        assert_eq!(signature.timezone, "Europe/Paris");
+        assert_eq!(signature.geolocation.altitude, 300);
+        assert_eq!(signature.geolocation.latitude, 45);
+        assert_eq!(signature.geolocation.longitude, 2);
+        assert_eq!(signature.signature.uri, expected_uri);
+    }
+}

--- a/src/fingerprinting/signature_format.rs
+++ b/src/fingerprinting/signature_format.rs
@@ -140,3 +140,269 @@ impl DecodedSignature {
     }
 
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Offsets into the 48-byte header, in the order `encode_to_binary` writes it.
+    const MAGIC1_OFFSET: usize = 0;
+    const CRC32_OFFSET: usize = 4;
+    const SIZE_MINUS_HEADER_OFFSET: usize = 8;
+    const MAGIC2_OFFSET: usize = 12;
+    const SHIFTED_SAMPLE_RATE_ID_OFFSET: usize = 28;
+    const NUMBER_SAMPLES_PLUS_OFFSET: usize = 40;
+    const FIXED_VALUE_OFFSET: usize = 44;
+    const HEADER_LENGTH: usize = 48;
+
+    // The body repeats its own length one `u32` in, and the bands start after that.
+    const BODY_SIZE_OFFSET: usize = HEADER_LENGTH + 4;
+    const FIRST_BAND_OFFSET: usize = HEADER_LENGTH + 8;
+
+    const SAMPLE_RATE_HZ: u32 = 16000;
+
+    fn read_u32(encoded: &[u8], offset: usize) -> u32 {
+        u32::from_le_bytes(encoded[offset..offset + 4].try_into().unwrap())
+    }
+
+    fn signature_of(bands: Vec<(FrequencyBand, Vec<FrequencyPeak>)>) -> DecodedSignature {
+        DecodedSignature {
+            sample_rate_hz: SAMPLE_RATE_HZ,
+            number_samples: 128000,
+            frequency_band_to_sound_peaks: bands.into_iter().collect(),
+        }
+    }
+
+    // Walks the band list the way a reader of the format has to: a marker, a length,
+    //  that many bytes of peaks, then padding up to the next multiple of four.
+    fn band_markers(encoded: &[u8]) -> Vec<u32> {
+        let mut markers = vec![];
+        let mut offset = FIRST_BAND_OFFSET;
+
+        while offset < encoded.len() {
+            markers.push(read_u32(encoded, offset));
+
+            let peaks_length = read_u32(encoded, offset + 4) as usize;
+            offset += 8 + peaks_length + (4 - peaks_length % 4) % 4;
+        }
+
+        markers
+    }
+
+    #[test]
+    fn the_header_carries_the_two_magic_values_and_the_sample_rate_id() {
+        let encoded = signature_of(vec![]).encode_to_binary().unwrap();
+
+        assert_eq!(read_u32(&encoded, MAGIC1_OFFSET), 0xcafe2580);
+        assert_eq!(read_u32(&encoded, MAGIC2_OFFSET), 0x94119c00);
+        // 16 kHz is sample-rate id 3, and the field holds it shifted left by 27.
+        assert_eq!(read_u32(&encoded, SHIFTED_SAMPLE_RATE_ID_OFFSET), 3 << 27);
+        assert_eq!(read_u32(&encoded, FIXED_VALUE_OFFSET), (15 << 19) + 0x40000);
+    }
+
+    #[test]
+    fn the_sample_count_is_padded_by_240_ms_worth_of_samples() {
+        let encoded = signature_of(vec![]).encode_to_binary().unwrap();
+
+        assert_eq!(
+            read_u32(&encoded, NUMBER_SAMPLES_PLUS_OFFSET),
+            128000 + (SAMPLE_RATE_HZ as f32 * 0.24) as u32,
+        );
+    }
+
+    #[test]
+    fn every_supported_sample_rate_has_its_own_id() {
+        for (sample_rate_hz, sample_rate_id) in
+            [(8000, 1), (11025, 2), (16000, 3), (32000, 4), (44100, 5), (48000, 6)]
+        {
+            let encoded = DecodedSignature {
+                sample_rate_hz,
+                number_samples: 0,
+                frequency_band_to_sound_peaks: HashMap::new(),
+            }
+            .encode_to_binary()
+            .unwrap();
+
+            assert_eq!(
+                read_u32(&encoded, SHIFTED_SAMPLE_RATE_ID_OFFSET),
+                sample_rate_id << 27,
+            );
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "Invalid sample rate")]
+    fn an_unsupported_sample_rate_panics() {
+        let signature = DecodedSignature {
+            sample_rate_hz: 22050,
+            number_samples: 0,
+            frequency_band_to_sound_peaks: HashMap::new(),
+        };
+
+        signature.encode_to_binary().unwrap();
+    }
+
+    #[test]
+    fn both_length_fields_hold_everything_after_the_header() {
+        let encoded = signature_of(vec![(
+            FrequencyBand::_250_520,
+            vec![FrequencyPeak {
+                fft_pass_number: 0,
+                peak_magnitude: 0x1234,
+                corrected_peak_frequency_bin: 0x5678,
+            }],
+        )])
+        .encode_to_binary()
+        .unwrap();
+
+        let body_length = (encoded.len() - HEADER_LENGTH) as u32;
+
+        assert_eq!(read_u32(&encoded, SIZE_MINUS_HEADER_OFFSET), body_length);
+        assert_eq!(read_u32(&encoded, BODY_SIZE_OFFSET), body_length);
+    }
+
+    #[test]
+    fn the_crc32_covers_every_byte_after_itself() {
+        let encoded = signature_of(vec![(
+            FrequencyBand::_1450_3500,
+            vec![FrequencyPeak {
+                fft_pass_number: 3,
+                peak_magnitude: 7,
+                corrected_peak_frequency_bin: 9,
+            }],
+        )])
+        .encode_to_binary()
+        .unwrap();
+
+        let mut hasher = Hasher::new();
+        hasher.update(&encoded[CRC32_OFFSET + 4..]);
+
+        assert_eq!(read_u32(&encoded, CRC32_OFFSET), hasher.finalize());
+    }
+
+    #[test]
+    fn a_peak_is_written_as_a_delta_from_the_previous_fft_pass() {
+        let encoded = signature_of(vec![(
+            FrequencyBand::_250_520,
+            vec![
+                FrequencyPeak {
+                    fft_pass_number: 0,
+                    peak_magnitude: 0x1234,
+                    corrected_peak_frequency_bin: 0x5678,
+                },
+                FrequencyPeak {
+                    fft_pass_number: 7,
+                    peak_magnitude: 0x4321,
+                    corrected_peak_frequency_bin: 0x8765,
+                },
+            ],
+        )])
+        .encode_to_binary()
+        .unwrap();
+
+        assert_eq!(
+            &encoded[FIRST_BAND_OFFSET + 8..FIRST_BAND_OFFSET + 18],
+            &[0, 0x34, 0x12, 0x78, 0x56, 7, 0x21, 0x43, 0x65, 0x87],
+        );
+    }
+
+    #[test]
+    fn a_gap_of_255_passes_or_more_is_escaped_with_an_absolute_pass_number() {
+        let encoded = signature_of(vec![(
+            FrequencyBand::_250_520,
+            vec![
+                FrequencyPeak {
+                    fft_pass_number: 0,
+                    peak_magnitude: 1,
+                    corrected_peak_frequency_bin: 2,
+                },
+                FrequencyPeak {
+                    fft_pass_number: 300,
+                    peak_magnitude: 3,
+                    corrected_peak_frequency_bin: 4,
+                },
+            ],
+        )])
+        .encode_to_binary()
+        .unwrap();
+
+        // A delta byte cannot express 300, so the escape writes the pass number whole
+        //  and the delta that follows it is zero.
+        assert_eq!(
+            &encoded[FIRST_BAND_OFFSET + 13..FIRST_BAND_OFFSET + 23],
+            &[0xff, 0x2c, 0x01, 0x00, 0x00, 0, 3, 0, 4, 0],
+        );
+    }
+
+    #[test]
+    fn a_band_is_padded_to_a_multiple_of_four_bytes() {
+        let encoded = signature_of(vec![(
+            FrequencyBand::_250_520,
+            vec![FrequencyPeak {
+                fft_pass_number: 0,
+                peak_magnitude: 1,
+                corrected_peak_frequency_bin: 2,
+            }],
+        )])
+        .encode_to_binary()
+        .unwrap();
+
+        // One peak is five bytes, so three bytes of padding follow it.
+        assert_eq!(read_u32(&encoded, FIRST_BAND_OFFSET + 4), 5);
+        assert_eq!(encoded.len(), FIRST_BAND_OFFSET + 8 + 5 + 3);
+        assert_eq!(&encoded[encoded.len() - 3..], &[0, 0, 0]);
+    }
+
+    #[test]
+    fn bands_are_written_in_ascending_order_whatever_the_map_hands_back() {
+        let peak = || FrequencyPeak {
+            fft_pass_number: 0,
+            peak_magnitude: 1,
+            corrected_peak_frequency_bin: 2,
+        };
+
+        // Inserted highest band first, and `HashMap` iteration order is randomised per
+        //  process anyway -- the sort in `encode_to_binary` is the only thing making
+        //  the output stable, and the golden fingerprints depend on it.
+        let encoded = signature_of(vec![
+            (FrequencyBand::_3500_5500, vec![peak()]),
+            (FrequencyBand::_520_1450, vec![peak()]),
+            (FrequencyBand::_1450_3500, vec![peak()]),
+            (FrequencyBand::_250_520, vec![peak()]),
+        ])
+        .encode_to_binary()
+        .unwrap();
+
+        assert_eq!(
+            band_markers(&encoded),
+            vec![0x60030040, 0x60030041, 0x60030042, 0x60030043],
+        );
+
+        // The sort reaches `Ord`; the `<` here is what reaches `PartialOrd`, and the two
+        //  are written out separately, so a divergence between them would go unnoticed.
+        assert!(FrequencyBand::_250_520 < FrequencyBand::_3500_5500);
+        assert_eq!(
+            FrequencyBand::_520_1450.partial_cmp(&FrequencyBand::_520_1450),
+            Some(Ordering::Equal),
+        );
+    }
+
+    #[test]
+    fn the_uri_is_the_prefix_and_the_binary_survives_a_base64_round_trip() {
+        let signature = signature_of(vec![(
+            FrequencyBand::_520_1450,
+            vec![FrequencyPeak {
+                fft_pass_number: 11,
+                peak_magnitude: 22,
+                corrected_peak_frequency_bin: 33,
+            }],
+        )]);
+
+        let uri = signature.encode_to_uri().unwrap();
+
+        let payload = uri.strip_prefix(DATA_URI_PREFIX).unwrap();
+        let decoded = general_purpose::STANDARD.decode(payload).unwrap();
+
+        assert_eq!(decoded, signature.encode_to_binary().unwrap());
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,3 +133,15 @@ impl Recognizer {
         python_future.map(|any| any.unbind())
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // The same default `SearchParams` carries, and `shazamio_core.pyi` documents.
+    #[test]
+    fn a_recognizer_defaults_to_a_ten_second_segment() {
+        assert_eq!(Recognizer::new(None).segment_duration_seconds, 10);
+        assert_eq!(Recognizer::new(Some(4)).segment_duration_seconds, 4);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,4 +144,27 @@ mod tests {
         assert_eq!(Recognizer::new(None).segment_duration_seconds, 10);
         assert_eq!(Recognizer::new(Some(4)).segment_duration_seconds, 4);
     }
+
+    // The module and `shazamio_core.pyi` declare the same six names by hand, so
+    //  nothing but this catches an export that was added to one and not the other.
+    #[test]
+    fn the_module_exports_every_name_the_stub_declares() {
+        Python::initialize();
+
+        Python::attach(|py| {
+            let module = PyModule::new(py, "shazamio_core").unwrap();
+            shazamio_core(&module).unwrap();
+
+            for name in [
+                "Geolocation",
+                "Recognizer",
+                "SearchParams",
+                "Signature",
+                "SignatureError",
+                "SignatureSong",
+            ] {
+                assert!(module.getattr(name).is_ok(), "{name} is not exported");
+            }
+        });
+    }
 }

--- a/src/params.rs
+++ b/src/params.rs
@@ -17,3 +17,14 @@ impl SearchParams {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn the_segment_duration_defaults_to_ten_seconds() {
+        assert_eq!(SearchParams::new(None).segment_duration_seconds, 10);
+        assert_eq!(SearchParams::new(Some(4)).segment_duration_seconds, 4);
+    }
+}

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -44,3 +44,44 @@ pub fn unwrap_decoded_signature(data: DecodedSignature) -> Result<communication:
         PyErr::new::<SignatureError, _>(error_message)
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    // `get_python_future` is not here: it needs a running `asyncio` loop, which is
+    //  what the Python suite already gives it.
+
+    // The conversion maps its fields positionally, so every one of them is pinned
+    //  rather than a sample: a swapped `latitude`/`longitude` type-checks.
+    #[test]
+    fn the_response_carries_every_field_of_the_signature_it_converts() {
+        let decoded = DecodedSignature {
+            sample_rate_hz: 16000,
+            number_samples: 24_500,
+            frequency_band_to_sound_peaks: HashMap::new(),
+        };
+
+        let signature = unwrap_decoded_signature(decoded).unwrap();
+
+        let altitude = signature.geolocation.altitude;
+        let latitude = signature.geolocation.latitude;
+        let longitude = signature.geolocation.longitude;
+
+        let samples = signature.signature.samples;
+        let timestamp = signature.timestamp;
+        let timezone = signature.timezone.clone();
+        let uri = signature.signature.uri.clone();
+
+        let converted = convert_signature_to_py(signature).unwrap();
+
+        assert_eq!(converted.geolocation.altitude, altitude);
+        assert_eq!(converted.geolocation.latitude, latitude);
+        assert_eq!(converted.geolocation.longitude, longitude);
+        assert_eq!(converted.signature.samples, samples);
+        assert_eq!(converted.signature.uri, uri);
+        assert_eq!(converted.timestamp, timestamp);
+        assert_eq!(converted.timezone, timezone);
+    }
+}


### PR DESCRIPTION
## What

The first Rust tests in the crate — 25 unit tests, up from none — plus a `cargo test` job that `release` waits on.

Most of them cover the binary signature format and the peak encoding in `src/fingerprinting/`. Two more cover the Python-facing edge: that the module exports every name `shazamio_core.pyi` declares, and that the signature conversion carries every field rather than dropping one.

Getting `cargo test` to link at all needed one build change, which is its own commit — see **The `extension-module` feature** below.

## Why

The golden fingerprint test can say the emitted signature changed. It cannot say *how*, because the thing it compares is 2 kB of opaque base64 — and it only exercises the format through one code path, whichever bytes that one probe file happens to produce.

The binary format has several rules a change can break silently while still producing a valid-looking URI: two magic values, a sample-rate id shifted by 27, a CRC32 taken over everything after itself, peaks delta-encoded against the previous FFT pass with an escape for gaps of 255 or more, each band padded to a multiple of four bytes, and the bands themselves sorted — they come out of a `HashMap`, whose iteration order is randomised per process, so without the sort the output would differ run to run.

The two binding tests cover a different failure: the module list in `lib.rs` and the names in `shazamio_core.pyi` are written out by hand, twice, with nothing comparing them. An export added to one and not the other is invisible until an import fails at a user's site.

## Tests

Each format test was checked by breaking the thing it covers and confirming it goes red:

| change to the code | test that fails |
| --- | --- |
| `NonEmptySpans` stops mapping `Some(0)` to `None` | `a_zero_length_span_is_reported_as_unbounded` |
| the band sort is reversed | `bands_are_written_in_ascending_order_whatever_the_map_hands_back` |
| the per-band padding loop is dropped | `a_band_is_padded_to_a_multiple_of_four_bytes` |
| the CRC32 starts at byte 4 instead of byte 8 | `the_crc32_covers_every_byte_after_itself` |
| the escape marker becomes `0xfe` | `a_gap_of_255_passes_or_more_is_escaped_with_an_absolute_pass_number` |

All five fail exactly one test each, except the padding one, which also fails the band-order test — the walker in that test reads the length-and-padding layout to find the next band.

## The `extension-module` feature

`pyo3/extension-module` was on by default in `Cargo.toml`. It suppresses the link to `libpython`, which is right for the `.so` a wheel ships — the interpreter is already in the process — and fatal for a test binary, which is an executable with no interpreter to borrow symbols from. With the feature on, `cargo test` fails to link.

pyo3 0.29 deprecates the feature for exactly this reason and says to drop it and let the build backend turn extension-module linking on instead, which maturin does from 1.9.4:

https://pyo3.rs/v0.29.0/faq.html#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror

So the `[features]` block is gone, `build-system.requires` moves to `maturin>=1.9.4`, and the dev-dependency floor moves with it. The wheels are unaffected: a local `maturin build` produces a `.so` with no `libpython` in its `DT_NEEDED` list, and the Python suite passes against it.

The one thing this costs is that `cargo test` now needs an interpreter built `--enable-shared`, since it links `libpython` for real. The job therefore runs `actions/setup-python` first — those Linux builds are configured `--enable-shared`:

https://github.com/actions/python-versions/blob/c2033aa6c313f068f4bde238bfaa5987ad4f2e79/builders/ubuntu-python-builder.psm1#L37

A system interpreter without the development `.so` will not link locally. `PYO3_PYTHON` pointed at one that has it is enough.

Dropping the feature broke the `manylinux` images, which is the last commit here. Both of them run `cargo chef cook` to warm the dependency cache, and that is plain `cargo` running before `maturin` is ever invoked — so nothing turns extension-module linking on for it, and no interpreter in those images ships a `libpython`:

```
error: could not find native static library `python3.9`, perhaps an -L flag is missing?
error: could not compile `pyo3-ffi` (lib) due to 1 previous error
```

`PYO3_BUILD_EXTENSION_MODULE=1` on that one `RUN` line is the documented replacement for the feature and fixes it. It is scoped to the step rather than set as an `ENV` on the stage: a stage-wide variable would silently stop a future `cargo test` in the same image from linking `libpython`, which is exactly what that test needs.

Verified by building the X64 image end to end: both the `cp39-abi3` and the `pp311` wheel come out as before.

## Choices worth flagging

**The job runs on one platform.** Byte layout, checksum and ordering do not vary by target. Whether the *fingerprint* is platform-stable is a different question, and the `test` job on `master` is what answers it.

**No toolchain step.** `ubuntu-latest` ships a stable Rust and the crate builds on it today; pinning a version here would be a second place to update whenever the MSRV moves.

## Not covered

`recognize_bytes`, `recognize_path` and `get_python_future` are not tested from Rust. All three hand work to `pyo3_async_runtimes`, which calls `asyncio.get_running_loop()` and fails outside a coroutine, so covering them here would mean embedding a Python coroutine as a string inside the Rust test — a worse copy of `tests/test_recognizer.py`, which already exercises them.

`SignatureGenerator` itself — the FFT, the peak picking, the ring buffers — needs a fixture of real samples to say anything, which is what the golden tests do end to end.

`decode_with_ffmpeg` shells out, so a unit test would need either ffmpeg present or a stub binary, and neither is portable across the three runners.

One observation while writing these, left alone deliberately: the `clamp(-1.0, 1.0)` in `to_i16` changes no result. A float-to-int cast in Rust saturates, so `4.0` and `1.0` both land on `32767` with or without it. Removing it passes every test here — but it states the intent, and this branch is about adding tests, not editing what they cover.

## How to test

```
cargo test
```

Locally, if the default interpreter has no shared `libpython`:

```
PYO3_PYTHON=/path/to/python-with-libpython.so cargo test
```

