### PR TITLE
ci: stop rebuilding on every push to master/dev

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,10 +2,11 @@ name: shazamio-core CI
 
 on:
   workflow_dispatch:
+  # Every change lands through a PR, so `pull_request` below already builds and
+  #  tests it before merge. Building again on the merge commit itself would just
+  #  repeat that, on code the PR run already covered -- so `push` is left to the
+  #  one case a PR can't cover: publishing a tag.
   push:
-    branches:
-      - 'master'
-      - 'dev'
     tags:
       - '*'
   pull_request:


### PR DESCRIPTION
## What

Scopes the `push` trigger down to tags only, dropping `branches: [master, dev]`.

## Why

Every change in this repository lands through a PR, and `pull_request` already builds and tests the full matrix before merge. With `push` also triggering on `master`/`dev`, merging a PR built the exact same tree a second time — once for the `synchronize` event on the PR branch, once more for the merge commit landing on `master` — for no additional coverage. `push` now covers only the one event `pull_request` can't: publishing a tag, which is what `release` gates on anyway.

## Not covered

A direct push to `master`/`dev` outside a PR would no longer trigger CI. That matches how this repository is actually used — everything goes through a PR — but is worth knowing if that changes.
