### PR TITLE
fix(tests): pass a `Path` to `make_signature_from_file`

### DIFF
--- a/src/fingerprinting/algorithm.rs
+++ b/src/fingerprinting/algorithm.rs
@@ -386,14 +386,15 @@ impl SignatureGenerator {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::path::PathBuf;
 
     // The probe and its pinned URI are the ones `tests/` uses; `tests/data/generate.sh`
     //  regenerates the audio. Reading them here rather than restating the expected
     //  bytes keeps one copy of the golden.
     const DATA_DIRECTORY: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/data");
 
-    fn probe_path() -> String {
-        format!("{DATA_DIRECTORY}/probe.flac")
+    fn probe_path() -> PathBuf {
+        Path::new(DATA_DIRECTORY).join("probe.flac")
     }
 
     fn golden_uri() -> String {
@@ -522,7 +523,7 @@ mod tests {
     #[test]
     fn input_no_decoder_understands_is_an_error() {
         let not_audio = SignatureGenerator::make_signature_from_bytes(b"not audio".to_vec(), None);
-        let script = format!("{DATA_DIRECTORY}/generate.sh");
+        let script = Path::new(DATA_DIRECTORY).join("generate.sh");
         let not_a_sound_file = SignatureGenerator::make_signature_from_file(&script, None);
 
         assert!(not_audio.is_err());


### PR DESCRIPTION
## What

`probe_path()` in the `#[cfg(test)]` module now returns a `PathBuf`, and the
`generate.sh` path in `input_no_decoder_understands_is_an_error` becomes one too.

## Why

`master` does not compile. #34 changed `SignatureGenerator::make_signature_from_file`
to take a `&Path`; #35 added test helpers that call it with a `&String`. Both were
green on their own branches and neither saw the other, so the merge broke three call
sites:

```
error[E0308]: mismatched types
   --> src/fingerprinting/algorithm.rs:470:70
    |
470 |         let signature = SignatureGenerator::make_signature_from_file(&probe_path(), None).unwrap();
    |                         -------------------------------------------- ^^^^^^^^^^^^^ expected `&Path`, found `&String`
    |
    = note: expected reference `&std::path::Path`
               found reference `&std::string::String`
```

Only the test target is affected — the library itself compiles, so the published
wheel is fine.

Nothing caught it because the workflow runs on `pull_request` and on tags only
(#36), so `cargo test` never runs against `master` itself. A pull request opened
against the current `master` will now go red on `Rust unit tests` until this lands.

## How to test

```
cargo test
```

`25 passed` on this branch; three compile errors on `master`.
