### PR TITLE
build(python): drop the end-of-life 3.9 floor and build `abi3-py310` wheels

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,9 +81,9 @@ jobs:
       - name: Run the unit tests
         run: cargo test
 
-  # The wheels below are abi3: one per platform, loading on every CPython from 3.9
-  # up. There is no per-interpreter matrix any more, so a new CPython release
-  # needs no change here and no new release.
+  # The wheels below are abi3: one per platform, loading on every CPython from 3.10
+  #  up. There is no per-interpreter matrix any more, so a new CPython release
+  #  needs no change here and no new release. The floor lives in `Cargo.toml`.
   windows:
    runs-on: windows-latest
    strategy:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,14 @@ chfft = {version = "0.3.4"}
 futures = { version = "0.3.34", features = [] }
 serde = { version = "1.0.229", features = ["derive"] }
 bytes = "1.12.1"
-# `abi3-py39` builds one wheel per platform that loads on every CPython from 3.9
-# up, instead of one wheel per interpreter version. A new CPython release then
-# needs no new wheel and no release at all -- which is what 3.13 and 3.14 each
-# needed under the old layout.
-pyo3 = { version = "=0.29.2", features = ["abi3-py39"] }
+# `abi3-py310` builds one wheel per platform that loads on every CPython from 3.10
+#  up, instead of one wheel per interpreter version. A new CPython release then
+#  needs no new wheel and no release at all -- which is what 3.13 and 3.14 each
+#  needed under the old layout.
+#  3.9 went end-of-life in October 2025, so nothing is left to build for below 3.10.
+#  https://devguide.python.org/versions/
+#  `requires-python` in `pyproject.toml` states the same floor for `pip`.
+pyo3 = { version = "=0.29.2", features = ["abi3-py310"] }
 pyo3-async-runtimes = { version = "0.29.0", features = ["tokio-runtime"] }
 pyo3-log = "=0.13.4"
 log = "0.4.33"

--- a/docker/Dockerfile.manylinux_2_28_ARM64
+++ b/docker/Dockerfile.manylinux_2_28_ARM64
@@ -11,7 +11,10 @@ RUN dnf install -y epel-release
 RUN dnf install -y --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm
 RUN dnf install -y --nogpgcheck https://download1.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-8.noarch.rpm
 RUN dnf install -y clang clang-devel
-ENV PATH="/root/.cargo/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:/opt/python/cp312-cp312/bin:$PATH"
+# Only the minimum supported interpreter belongs here: the wheel is `abi3`, so one
+#  is emitted whatever builds it, and this entry stays only so `pip3` below exists
+#  at all. Must match the `abi3-py*` feature in `Cargo.toml`.
+ENV PATH="/root/.cargo/bin:/opt/python/cp310-cp310/bin:$PATH"
 # Must match `MATURIN_VERSION` in `.github/workflows/ci.yaml`, so every wheel of a
 # release is built by one `maturin`.
 RUN pip3 install maturin==1.14.1 patchelf cffi ziglang sccache>=0.4.0

--- a/docker/Dockerfile.manylinux_2_28_ARM64
+++ b/docker/Dockerfile.manylinux_2_28_ARM64
@@ -11,7 +11,7 @@ RUN dnf install -y epel-release
 RUN dnf install -y --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm
 RUN dnf install -y --nogpgcheck https://download1.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-8.noarch.rpm
 RUN dnf install -y clang clang-devel
-ENV PATH="/root/.cargo/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:/opt/python/cp312-cp312/bin:$PATH"
+ENV PATH="/root/.cargo/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:/opt/python/cp312-cp312/bin:$PATH"
 # Must match `MATURIN_VERSION` in `.github/workflows/ci.yaml`, so every wheel of a
 # release is built by one `maturin`.
 RUN pip3 install maturin==1.14.1 patchelf cffi ziglang sccache>=0.4.0
@@ -34,7 +34,8 @@ WORKDIR /opt
 COPY --from=planner /opt/recipe.json recipe.json
 # `cargo chef` runs plain `cargo` before `maturin` is ever invoked, so nothing turns
 #  extension-module linking on for it, and no interpreter in this image ships a
-#  `libpython` -- the step died on `could not find native static library python3.9`.
+#  `libpython` -- the step died on `could not find native static library python3.9`,
+#  naming whichever `cpXY` led `PATH` when that was written.
 #  Why the feature went away: the `[build-system]` comment in `pyproject.toml`.
 RUN PYO3_BUILD_EXTENSION_MODULE=1 cargo chef cook --release --recipe-path recipe.json
 COPY . .

--- a/docker/Dockerfile.manylinux_2_28_X64
+++ b/docker/Dockerfile.manylinux_2_28_X64
@@ -11,7 +11,10 @@ RUN dnf install -y epel-release
 RUN dnf install -y --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm
 RUN dnf install -y --nogpgcheck https://download1.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-8.noarch.rpm
 RUN dnf install -y clang clang-devel
-ENV PATH="/root/.cargo/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:/opt/python/cp312-cp312/bin:$PATH"
+# Only the minimum supported interpreter belongs here: the wheel is `abi3`, so one
+#  is emitted whatever builds it, and this entry stays only so `pip3` below exists
+#  at all. Must match the `abi3-py*` feature in `Cargo.toml`.
+ENV PATH="/root/.cargo/bin:/opt/python/cp310-cp310/bin:$PATH"
 # Must match `MATURIN_VERSION` in `.github/workflows/ci.yaml`, so every wheel of a
 # release is built by one `maturin`.
 RUN pip3 install maturin==1.14.1 patchelf cffi ziglang sccache>=0.4.0

--- a/docker/Dockerfile.manylinux_2_28_X64
+++ b/docker/Dockerfile.manylinux_2_28_X64
@@ -11,7 +11,7 @@ RUN dnf install -y epel-release
 RUN dnf install -y --nogpgcheck https://download1.rpmfusion.org/free/el/rpmfusion-free-release-8.noarch.rpm
 RUN dnf install -y --nogpgcheck https://download1.rpmfusion.org/nonfree/el/rpmfusion-nonfree-release-8.noarch.rpm
 RUN dnf install -y clang clang-devel
-ENV PATH="/root/.cargo/bin:/opt/python/cp39-cp39/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:/opt/python/cp312-cp312/bin:$PATH"
+ENV PATH="/root/.cargo/bin:/opt/python/cp310-cp310/bin:/opt/python/cp311-cp311/bin:/opt/python/cp312-cp312/bin:$PATH"
 # Must match `MATURIN_VERSION` in `.github/workflows/ci.yaml`, so every wheel of a
 # release is built by one `maturin`.
 RUN pip3 install maturin==1.14.1 patchelf cffi ziglang sccache>=0.4.0
@@ -34,7 +34,8 @@ WORKDIR /opt
 COPY --from=planner /opt/recipe.json recipe.json
 # `cargo chef` runs plain `cargo` before `maturin` is ever invoked, so nothing turns
 #  extension-module linking on for it, and no interpreter in this image ships a
-#  `libpython` -- the step died on `could not find native static library python3.9`.
+#  `libpython` -- the step died on `could not find native static library python3.9`,
+#  naming whichever `cpXY` led `PATH` when that was written.
 #  Why the feature went away: the `[build-system]` comment in `pyproject.toml`.
 RUN PYO3_BUILD_EXTENSION_MODULE=1 cargo chef cook --release --recipe-path recipe.json
 COPY . .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,10 @@ name = "shazamio_core"
 readme = "README.md"
 authors = [{name = "dotX12", email = "dev@shitposting.team"}]
 maintainers = [{name = "Danipulok", email = "danipulok@gmail.com"}]
-requires-python = ">=3.9"
+# Must match the `abi3-py*` feature in `Cargo.toml`, which is where the floor is
+#  argued: that feature is what the extension links against, this is only what
+#  `pip` refuses to install on.
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",


### PR DESCRIPTION
## What

Raises the Python floor from 3.9 to 3.10:

- `Cargo.toml` — the `pyo3` feature becomes `abi3-py310`. This is the load-bearing
  one: it sets the floor of the single abi3 wheel.
- `pyproject.toml` — `requires-python = ">=3.10"`, with a pointer at `Cargo.toml`
  so the two cannot drift silently.
- Both manylinux images — `cp39-cp39` comes off `PATH`.
- `CI.yml` — the comment above the `windows` job no longer claims the wheel loads
  on 3.9.

There is no Poetry constraint to change: `pyproject.toml` sets
`package-mode = false` and its Poetry section declares dev dependencies only.

## Why

3.9 reached end of life in October 2025: https://devguide.python.org/versions/

Worth knowing before merging: **3.10 goes end of life in October 2026**, about two
months out. 3.11 is a one-line change from here if you would rather skip a step —
say so and I will push it.

## How to test

```
cargo test
maturin build --release
```

`25 passed`, and the wheel comes out as `shazamio_core-1.2.0-cp310-abi3-*.whl` —
`cp310-abi3`, so the floor really moved. The manylinux job builds the same tag
inside the release image, now that `cp39` is off its `PATH`.
