### PR TITLE
ci(rust): gate on `cargo fmt --check` and `cargo clippy`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,6 +81,28 @@ jobs:
       - name: Run the unit tests
         run: cargo test
 
+  # Neither gate below is provided by anything else here: the wheel jobs compile the
+  #  crate, and a compiler is indifferent to formatting and to every lint `clippy`
+  #  adds on top of it. `clippy` runs at its own default level rather than with a
+  #  curated lint set -- this is a gate against new findings, not a rewrite of code
+  #  that predates it.
+  lint:
+    name: Rust lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - run: rustup component add rustfmt clippy
+
+      - name: Check the formatting
+        run: cargo fmt --all --check
+
+      # `--all-targets` is what reaches the `#[cfg(test)]` modules. The default target
+      #  set stops at the library, so every unit test would go unlinted.
+      #  https://doc.rust-lang.org/cargo/commands/cargo-clippy.html#target-selection
+      - name: Run `clippy`
+        run: cargo clippy --all-targets -- -D warnings
+
   # The wheels below are abi3: one per platform, loading on every CPython from 3.10
   #  up. There is no per-interpreter matrix any more, so a new CPython release
   #  needs no change here and no new release. The floor lives in `Cargo.toml`.
@@ -247,7 +269,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: "startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'"
-    needs: [ test, rust-test, sdist, macos, linux, windows ]
+    needs: [ test, rust-test, lint, sdist, macos, linux, windows ]
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/src/fingerprinting/algorithm.rs
+++ b/src/fingerprinting/algorithm.rs
@@ -76,11 +76,8 @@ impl<S: Source> Source for NonEmptySpans<S> {
 
 // Resample to the mono 16 kHz PCM the fingerprint is defined over.
 fn to_mono_16khz(source: impl Source) -> Vec<i16> {
-    let uniform = UniformSourceIterator::new(
-        NonEmptySpans(source),
-        TARGET_CHANNELS,
-        TARGET_SAMPLE_RATE,
-    );
+    let uniform =
+        UniformSourceIterator::new(NonEmptySpans(source), TARGET_CHANNELS, TARGET_SAMPLE_RATE);
     uniform.map(to_i16).collect()
 }
 
@@ -98,7 +95,10 @@ pub struct SignatureGenerator {
 }
 
 impl SignatureGenerator {
-    pub fn make_signature_from_bytes(bytes: Vec<u8>, segment_duration_seconds: Option<u32>) -> Result<DecodedSignature, Box<dyn Error>> {
+    pub fn make_signature_from_bytes(
+        bytes: Vec<u8>,
+        segment_duration_seconds: Option<u32>,
+    ) -> Result<DecodedSignature, Box<dyn Error>> {
         // Create a cursor around the byte array for decoding
         let cursor = Cursor::new(bytes.clone());
 
@@ -133,7 +133,10 @@ impl SignatureGenerator {
         // Return the generated signature
         Ok(signature)
     }
-    pub fn make_signature_from_file(file_path: &Path, segment_duration_seconds: Option<u32>) -> Result<DecodedSignature, Box<dyn Error>> {
+    pub fn make_signature_from_file(
+        file_path: &Path,
+        segment_duration_seconds: Option<u32>,
+    ) -> Result<DecodedSignature, Box<dyn Error>> {
         // Decode the .WAV, .MP3, .OGG or .FLAC file
 
         let mut decoder = rodio::Decoder::new(BufReader::new(std::fs::File::open(file_path)?));
@@ -160,7 +163,8 @@ impl SignatureGenerator {
 
         if raw_pcm_samples.len() > segment_samples {
             let middle = raw_pcm_samples.len() / 2;
-            raw_pcm_samples_slice = &raw_pcm_samples[middle - segment_samples/2 .. middle + segment_samples/2];
+            raw_pcm_samples_slice =
+                &raw_pcm_samples[middle - segment_samples / 2..middle + segment_samples / 2];
         }
 
         let res = SignatureGenerator::make_signature_from_buffer(raw_pcm_samples_slice.to_vec());
@@ -336,9 +340,8 @@ impl SignatureGenerator {
                             * 32.0
                             / peak_variation_1;
 
-                        let corrected_peak_frequency_bin: u16 = (
-                            (bin_position as i32 * 64) + (peak_variation_2 as i32)
-                        ) as u16;
+                        let corrected_peak_frequency_bin: u16 =
+                            ((bin_position as i32 * 64) + (peak_variation_2 as i32)) as u16;
 
                         assert!(peak_variation_1 >= 0.0);
 
@@ -363,7 +366,8 @@ impl SignatureGenerator {
                             }
                         };
 
-                        self.signature.frequency_band_to_sound_peaks
+                        self.signature
+                            .frequency_band_to_sound_peaks
                             .entry(frequency_band)
                             .or_default();
 

--- a/src/fingerprinting/ffmpeg_wrapper.rs
+++ b/src/fingerprinting/ffmpeg_wrapper.rs
@@ -15,7 +15,6 @@ use tempfile::Builder;
 /// This function used to decode a file with FFMpeg, if it is installed on
 /// the system, in the case where Rodio can't decode the concerned format
 /// (for example with .WMA, .M4A, etc.).
-
 pub fn decode_with_ffmpeg(file_path: &Path) -> Option<Decoder<BufReader<File>>> {
     // Find the path for FFMpeg, in the case where it is installed
 

--- a/src/fingerprinting/hanning.rs
+++ b/src/fingerprinting/hanning.rs
@@ -1,6 +1,5 @@
 /// Multipliers for applying hanning window over 2048 entries, with
 /// leading and trailing zeroes omitted.
-
 pub const HANNING_WINDOW_2048_MULTIPLIERS: [f32; 2048] = [
     0.0000023508,
     0.0000094032,

--- a/src/fingerprinting/signature_format.rs
+++ b/src/fingerprinting/signature_format.rs
@@ -31,7 +31,7 @@ impl Ord for FrequencyBand {
 
 impl PartialOrd for FrequencyBand {
     fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some((*self as i32).cmp(&(*other as i32)))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/fingerprinting/signature_format.rs
+++ b/src/fingerprinting/signature_format.rs
@@ -138,7 +138,6 @@ impl DecodedSignature {
             general_purpose::STANDARD.encode(self.encode_to_binary()?)
         ))
     }
-
 }
 
 #[cfg(test)]
@@ -212,9 +211,14 @@ mod tests {
 
     #[test]
     fn every_supported_sample_rate_has_its_own_id() {
-        for (sample_rate_hz, sample_rate_id) in
-            [(8000, 1), (11025, 2), (16000, 3), (32000, 4), (44100, 5), (48000, 6)]
-        {
+        for (sample_rate_hz, sample_rate_id) in [
+            (8000, 1),
+            (11025, 2),
+            (16000, 3),
+            (32000, 4),
+            (44100, 5),
+            (48000, 6),
+        ] {
             let encoded = DecodedSignature {
                 sample_rate_hz,
                 number_samples: 0,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,21 +1,21 @@
 mod errors;
 mod fingerprinting;
+mod params;
 mod response;
 mod utils;
-mod params;
 
 use crate::errors::SignatureError;
-use crate::response::{Geolocation, Signature, SignatureSong};
 use crate::params::SearchParams;
+use crate::response::{Geolocation, Signature, SignatureSong};
 use crate::utils::convert_signature_to_py;
 use crate::utils::get_python_future;
 use crate::utils::unwrap_decoded_signature;
 use fingerprinting::algorithm::SignatureGenerator;
+use log::{debug, error, info};
 use pyo3::prelude::*;
-use std::path::PathBuf;
-use pyo3::{pyclass, pymethods, pymodule, Bound, Py, PyAny, PyErr, PyResult, Python};
 use pyo3::types::PyModule;
-use log::{info, debug, error};
+use pyo3::{pyclass, pymethods, pymodule, Bound, Py, PyAny, PyErr, PyResult, Python};
+use std::path::PathBuf;
 
 #[pymodule]
 fn shazamio_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
@@ -46,8 +46,13 @@ impl Recognizer {
     #[pyo3(signature = (segment_duration_seconds=None))]
     pub fn new(segment_duration_seconds: Option<u32>) -> Self {
         let duration = segment_duration_seconds.unwrap_or(10);
-        info!("Recognizer created with segment_duration_seconds = {}", duration);
-        Recognizer { segment_duration_seconds: duration }
+        info!(
+            "Recognizer created with segment_duration_seconds = {}",
+            duration
+        );
+        Recognizer {
+            segment_duration_seconds: duration,
+        }
     }
 
     #[pyo3(signature = (value, options=None))]
@@ -76,7 +81,8 @@ impl Recognizer {
             let data = SignatureGenerator::make_signature_from_bytes(
                 value,
                 Some(search_options.segment_duration_seconds),
-            ).map_err(|e| {
+            )
+            .map_err(|e| {
                 error!("Error in make_signature_from_bytes: {}", e);
                 let error_message = format!("{}", e);
                 PyErr::new::<SignatureError, _>(error_message)
@@ -118,7 +124,8 @@ impl Recognizer {
             let data = SignatureGenerator::make_signature_from_file(
                 &value,
                 Some(search_options.segment_duration_seconds),
-            ).map_err(|e| {
+            )
+            .map_err(|e| {
                 debug!("Error in make_signature_from_file: {}", e);
                 let error_message = format!("{}", e);
                 PyErr::new::<SignatureError, _>(error_message)

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -14,11 +14,11 @@ pub fn get_python_future<'py, T>(
 where
     T: for<'a> IntoPyObject<'a> + Send + 'static,
 {
-    return pyo3_async_runtimes::tokio::future_into_py(py, async move {
+    pyo3_async_runtimes::tokio::future_into_py(py, async move {
         task::spawn_blocking(move || futures::executor::block_on(future))
             .await
             .unwrap()
-    });
+    })
 }
 
 pub fn convert_signature_to_py(signature: communication::Signature) -> PyResult<Signature> {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,10 +9,10 @@ use tokio::task;
 
 pub fn get_python_future<'py, T>(
     py: Python<'py>,
-    future: impl Future<Output=PyResult<T>> + Send + 'static,
+    future: impl Future<Output = PyResult<T>> + Send + 'static,
 ) -> PyResult<Bound<'py, PyAny>>
-    where
-        T: for<'a> IntoPyObject<'a> + Send + 'static,
+where
+    T: for<'a> IntoPyObject<'a> + Send + 'static,
 {
     return pyo3_async_runtimes::tokio::future_into_py(py, async move {
         task::spawn_blocking(move || futures::executor::block_on(future))


### PR DESCRIPTION
## What

- `rustfmt` applied to the crate — 14 hunks across four files, no behaviour change.
- The four findings `cargo clippy` reports at its default level are cleared:
  `empty_line_after_doc_comment` twice, `non_canonical_partial_ord_impl` and
  `needless_return`.
- A `lint` job runs both, and `release` now waits on it.

## Why

Nothing else in the workflow checks either one. The wheel jobs compile the crate,
and a compiler is indifferent to formatting and to every lint `clippy` adds on top
of it, so both drift freely.

Two deliberate limits on the gate:

- **`clippy` runs at its own default level**, not with a curated restriction set.
  Turning on `unwrap_used`, `expect_used`, `panic` and `indexing_slicing` alone
  fires on 80 sites across six files in `src/`. This is meant as a gate against new
  findings, not a rewrite of code that predates it.
- **`--all-targets` is not optional.** The default target set stops at the library,
  so every `#[cfg(test)]` module would go unlinted.
  https://doc.rust-lang.org/cargo/commands/cargo-clippy.html#target-selection

## How to test

```
cargo fmt --all --check
cargo clippy --all-targets -- -D warnings
cargo test
```

All three pass on this branch; `cargo test` still reports 25 passed.
