### PR TITLE
ci(cache): export the Docker build cache only from `master`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -196,7 +196,13 @@ jobs:
           push: false
           load: true
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # A pull request's cache is scoped to `refs/pull/N/merge`, which neither `master`
+          #  nor another pull request can read, so each one exported a full image of layers
+          #  nobody could reuse. That held the repository over the 10 GB limit, and eviction
+          #  is oldest-first, so the x86 image lost its layers before the next run read them
+          #  -- 0 cached layers, and 224s of a 441s build step spent re-exporting them.
+          #  https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching
+          cache-to: ${{ github.ref == 'refs/heads/master' && 'type=gha,mode=max' || '' }}
           context: .
 
       - name: List /opt/dist directory


### PR DESCRIPTION
## What

`cache-to` on the `linux` matrix is now gated on the ref being `master`. `cache-from` is untouched, so pull requests still read the trunk's cache — they just stop writing one.

## Why

A build cache is scoped to the ref that produced it, and a pull request writes under `refs/pull/N/merge`, which neither `master` nor any other pull request can read. With `mode=max` that meant every pull request exported every intermediate layer of both manylinux images, and none of it was ever reused by anything.

That would only be waste, except the exports also hold the repository over its cache quota:

```
$ gh api repos/shazamio/shazamio-core/actions/cache/usage
{"active_caches_size_in_bytes":11612640197,"active_caches_count":797}
```

11.6 GB against a 10 GB limit. Eviction deletes by last-access date, oldest first, so the larger x86 image loses its layers before the next run can read them. Measured on run 33261788909, where both jobs ran the same configuration:

| job | cached layers | duration |
|---|---|---|
| `linux ARM64` | 12 | 1m49s |
| `linux X64` | 0 | 7m54s |

Of the x86 job's 7m54s, 441s is the `Build docker image` step — and 224s of that is `exporting to GitHub Actions Cache`. Over half the job goes on writing back layers it had just rebuilt from scratch, which evicts further entries and sets up the next miss.

https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching

## How to test

A pull request run should no longer spend time in `exporting to GitHub Actions Cache`, and `linux X64` should drop by roughly the 224s that step was costing. Pushes to `master` still populate the cache, so the reads keep working.

Worth doing separately: the 797 entries already accumulated will age out on their own, but deleting the stale `refs/pull/*` ones would let this take effect now rather than over the next few weeks.
