### PR TITLE
ci(dependabot): cover `cargo` and the Python dependencies too

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,3 +11,36 @@ updates:
     commit-message:
       prefix: ci
       include: scope
+
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: build
+      include: scope
+    groups:
+      # `pyo3-async-runtimes` and `pyo3-log` are released against one `pyo3` minor
+      #  and both currently require 0.29, while `Cargo.toml` pins two of the three
+      #  exactly (`pyo3 = "=0.29.2"`, `pyo3-log = "=0.13.4"`). A pull request moving
+      #  one of them alone cannot resolve, so they travel together or not at all.
+      pyo3:
+        patterns:
+          - pyo3
+          - pyo3-*
+
+  # Poetry is served by the `pip` ecosystem; there is no `poetry` value.
+  #  https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories
+  - package-ecosystem: pip
+    directory: /
+    schedule:
+      interval: monthly
+    commit-message:
+      prefix: build
+      include: scope
+    ignore:
+      # `maturin` is pinned in four places and Dependabot reaches only this one.
+      #  `MATURIN_VERSION` in `ci.yaml` and `maturin==` in both manylinux Dockerfiles
+      #  are the versions wheels are actually built with, and a bump here alone would
+      #  raise the declared floor above every one of them without touching them.
+      - dependency-name: maturin


### PR DESCRIPTION
## What

Adds a `cargo` entry and a Python entry to the Dependabot config, which until now covered `github-actions` only. Both run monthly and label their commits with a `build` prefix.

Two settings are not defaults:

- **The three `pyo3` crates are grouped into one pull request.** `pyo3-async-runtimes` and `pyo3-log` are released against a single `pyo3` minor and both currently require 0.29, while `Cargo.toml` pins two of the three exactly — `pyo3 = "=0.29.2"` and `pyo3-log = "=0.13.4"`. A pull request moving one of them on its own cannot resolve, so grouping them is what makes the update actionable rather than automatically red.

- **`maturin` is excluded from the Python updates.** It is pinned in four places, and Dependabot reaches exactly one of them:

  ```
  .github/workflows/ci.yaml:35                MATURIN_VERSION: v1.14.1
  docker/Dockerfile.manylinux_2_28_X64:20     maturin==1.14.1
  docker/Dockerfile.manylinux_2_28_ARM64:20   maturin==1.14.1
  pyproject.toml:6                            maturin = "^1.9.4"
  pyproject.toml:15                           requires = ["maturin>=1.9.4"]
  ```

  A bump confined to `pyproject.toml` would raise the declared floor above the version every wheel is actually built with, and it would do so quietly: the Dockerfiles invoke `maturin build` directly, so `build-system.requires` is never enforced against them. Collapsing those pins to one source is worth doing on its own; until then, an ignore with the reason written next to it beats a pull request that desynchronizes them.

Poetry is served by the `pip` ecosystem — there is no `poetry` value for `package-ecosystem`.
https://docs.github.com/en/code-security/dependabot/ecosystems-supported-by-dependabot/supported-ecosystems-and-repositories

## Why

`Cargo.toml` and `pyproject.toml` were updated by hand or not at all, which is how the four crate updates currently outstanding went unnoticed. The SHA pins in `ci.yaml` already had this covered; the dependencies did not.

## How to test

The config validates against the published Dependabot 2.0 schema. The group patterns were glob-matched against the real `[dependencies]` list and select `pyo3`, `pyo3-async-runtimes` and `pyo3-log` — and notably not the unrelated `log` crate.

After merging, the first monthly run should open at most one pull request per ecosystem plus one for the `pyo3` group. Dependabot also re-reads the config on push, so the parse can be confirmed straight away under Insights → Dependency graph → Dependabot.
