### PR TITLE
ci(maturin): take the pinned version as a build argument

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -39,8 +39,8 @@ updates:
       prefix: build
       include: scope
     ignore:
-      # `maturin` is pinned in four places and Dependabot reaches only this one.
-      #  `MATURIN_VERSION` in `ci.yaml` and `maturin==` in both manylinux Dockerfiles
-      #  are the versions wheels are actually built with, and a bump here alone would
-      #  raise the declared floor above every one of them without touching them.
+      # `maturin` is pinned in three places and Dependabot reaches only this one.
+      #  `MATURIN_VERSION` in `ci.yaml` is the version every wheel is actually built
+      #  with, and `build-system.requires` is the floor an sdist builder must meet.
+      #  A bump here alone moves neither, so the three drift apart silently.
       - dependency-name: maturin

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -28,9 +28,10 @@ permissions:
   pages: write
   id-token: write
 
-# `maturin-action` installs the latest release unless told otherwise, so without
-# this the Linux wheels and the macOS/Windows wheels of one release come out of
-# different `maturin` versions. Must match `maturin==` in `docker/Dockerfile.manylinux_2_28_*`.
+# The one place the built-with version is stated. `maturin-action` installs the
+#  latest release unless told otherwise, and the manylinux images take this as a
+#  build argument, so without it the Linux wheels and the macOS/Windows wheels of
+#  one release come out of different `maturin` versions.
 env:
   MATURIN_VERSION: v1.14.1
 
@@ -192,6 +193,8 @@ jobs:
         with:
           file: ${{ matrix.docker_file }}
           platforms: ${{ matrix.arch }}
+          build-args: |
+            MATURIN_VERSION=${{ env.MATURIN_VERSION }}
           tags: shazamio_core
           push: false
           load: true

--- a/docker/Dockerfile.manylinux_2_28_ARM64
+++ b/docker/Dockerfile.manylinux_2_28_ARM64
@@ -15,9 +15,14 @@ RUN dnf install -y clang clang-devel
 #  is emitted whatever builds it, and this entry stays only so `pip3` below exists
 #  at all. Must match the `abi3-py*` feature in `Cargo.toml`.
 ENV PATH="/root/.cargo/bin:/opt/python/cp310-cp310/bin:$PATH"
-# Must match `MATURIN_VERSION` in `.github/workflows/ci.yaml`, so every wheel of a
-# release is built by one `maturin`.
-RUN pip3 install maturin==1.14.1 patchelf cffi ziglang sccache>=0.4.0
+# The one pin lives in `MATURIN_VERSION` in `.github/workflows/ci.yaml` and arrives
+#  here as a build argument, so the Linux wheels and the macOS/Windows wheels of a
+#  release cannot come out of different `maturin` versions. Unset is a hard error
+#  rather than a default: a default is the second copy this removes. The tag carries
+#  a `v` that no other site uses, so it is stripped.
+ARG MATURIN_VERSION
+RUN : "${MATURIN_VERSION:?the MATURIN_VERSION build argument is required}" \
+ && pip3 install "maturin==${MATURIN_VERSION#v}" patchelf cffi ziglang sccache>=0.4.0
 
 WORKDIR /opt
 COPY docker/install-basic-deps-manylinux.sh .

--- a/docker/Dockerfile.manylinux_2_28_ARM64
+++ b/docker/Dockerfile.manylinux_2_28_ARM64
@@ -3,7 +3,7 @@
 #  checks the result, so a silent rebuild underneath would land in a release
 #  unnoticed. The tag must be the SAME in both images, or the x86 and arm wheels of
 #  one release come out of different toolchains.
-#  https://quay.io/repository/pypa/manylinux_2_28_x86_64?tab=tags
+#  https://quay.io/repository/pypa/manylinux_2_28_aarch64?tab=tags
 FROM quay.io/pypa/manylinux_2_28_aarch64:2026.08.24-1 AS base
 
 RUN dnf install -y epel-release

--- a/docker/Dockerfile.manylinux_2_28_X64
+++ b/docker/Dockerfile.manylinux_2_28_X64
@@ -15,9 +15,14 @@ RUN dnf install -y clang clang-devel
 #  is emitted whatever builds it, and this entry stays only so `pip3` below exists
 #  at all. Must match the `abi3-py*` feature in `Cargo.toml`.
 ENV PATH="/root/.cargo/bin:/opt/python/cp310-cp310/bin:$PATH"
-# Must match `MATURIN_VERSION` in `.github/workflows/ci.yaml`, so every wheel of a
-# release is built by one `maturin`.
-RUN pip3 install maturin==1.14.1 patchelf cffi ziglang sccache>=0.4.0
+# The one pin lives in `MATURIN_VERSION` in `.github/workflows/ci.yaml` and arrives
+#  here as a build argument, so the Linux wheels and the macOS/Windows wheels of a
+#  release cannot come out of different `maturin` versions. Unset is a hard error
+#  rather than a default: a default is the second copy this removes. The tag carries
+#  a `v` that no other site uses, so it is stripped.
+ARG MATURIN_VERSION
+RUN : "${MATURIN_VERSION:?the MATURIN_VERSION build argument is required}" \
+ && pip3 install "maturin==${MATURIN_VERSION#v}" patchelf cffi ziglang sccache>=0.4.0
 
 WORKDIR /opt
 COPY docker/install-basic-deps-manylinux.sh .


### PR DESCRIPTION
## What

The `maturin` version was written in three places that all have to agree — `MATURIN_VERSION` in the workflow and `maturin==1.14.1` in both manylinux Dockerfiles. Nothing related them.

Both manylinux images take the version as a build argument now instead of restating it, so `MATURIN_VERSION` is the only exact pin left. An unset argument is a hard error rather than a default, because a default would be the second copy this removes; the `v` the workflow's tag carries is stripped in the shell.

`.github/dependabot.yml` keeps its `maturin` ignore; only the comment beside it changes, since the two Dockerfiles it named no longer restate the version.

## Why

Three exact pins that must be equal, with nothing keeping them equal. A bump that edits the workflow and misses one Dockerfile ships a release whose x86 and arm wheels came out of different toolchains, and no job would say so.

The two floors in `pyproject.toml` are deliberately lower and are untouched here — they are a compatibility claim for anyone building the sdist, argued in the comment beside them.

## How to test

The `linux` legs of this run are the proof: they build both images through `docker/build-push-action`, and an image the argument does not reach fails the build outright — `pip3 install` never runs without it.

## Unrelated one-liner, folded in

The second commit fixes one word in a comment in `docker/Dockerfile.manylinux_2_28_ARM64`: the link above the `FROM` pointed at the **x86_64** tag list while the line below pins `aarch64`, a copy-paste from the sibling file. It changes no build. It rides along here rather than as its own pull request because this is the change that already opens that file — say the word and I will drop it.
