### PR TITLE
fix(typing): export the public names from the package root

### DIFF
--- a/shazamio_core/__init__.py
+++ b/shazamio_core/__init__.py
@@ -6,3 +6,12 @@ from .shazamio_core import (
     Recognizer,
     SearchParams,
 )
+
+__all__ = [
+    "Geolocation",
+    "Recognizer",
+    "SearchParams",
+    "Signature",
+    "SignatureError",
+    "SignatureSong",
+]

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,16 @@
+import shazamio_core
+from shazamio_core import shazamio_core as extension
+
+
+def test_package_exports_everything_the_extension_declares() -> None:
+    """`py.typed` makes a plain `from .shazamio_core import Name` export nothing.
+
+    Under the PEP 484 re-export rules the name is importable at runtime and is a
+    `reportPrivateImportUsage` error under `pyright` for everyone who follows the
+    README. `__all__` in `__init__.py` is what makes the six names public.
+    https://typing.python.org/en/latest/spec/distributing.html#import-conventions
+    """
+    # `pyo3` appends every name to the module's `__all__` as it is added, so the
+    #  extension's list is the whole surface the Rust side declares.
+    #  https://github.com/PyO3/pyo3/blob/v0.29.2/src/types/module.rs#L497-L502
+    assert sorted(shazamio_core.__all__) == sorted(extension.__all__)


### PR DESCRIPTION
## What

`shazamio_core/__init__.py` declares `__all__`, and a test pins it to the surface the extension declares.

## Why

The package ships `py.typed`, which opts it into PEP 484's re-export rule: in a typed package a plain `from .shazamio_core import Name` binds the name for that module and does **not** make it part of the package's public interface. Only `import X as X` / `from Y import X as X`, or membership in `__all__`, does.

> if the source file is a stub file or the package is `py.typed`, only imports of the form `import X as X` and `from Y import X as X` are re-exported

https://typing.python.org/en/latest/spec/distributing.html#import-conventions

So every import the README writes is an error under `pyright`, the engine behind Pylance and therefore the default type checker in VS Code. Measured against the wheel built from `master` (`shazamio_core-1.2.0-cp310-abi3-manylinux_2_39_x86_64`), installed into a clean Python 3.14 project:

```
error  reportPrivateImportUsage  "Geolocation" is not exported from module "shazamio_core"
error  reportPrivateImportUsage  "Recognizer" is not exported from module "shazamio_core"
error  reportPrivateImportUsage  "SearchParams" is not exported from module "shazamio_core"
error  reportPrivateImportUsage  "Signature" is not exported from module "shazamio_core"
error  reportPrivateImportUsage  "SignatureError" is not exported from module "shazamio_core"
error  reportPrivateImportUsage  "SignatureSong" is not exported from module "shazamio_core"
```

`mypy` reports none of them, because `--no-implicit-reexport` is off outside `--strict` — which is why this has stayed invisible to CI.

With `__all__` in place all six are gone, and the stub still resolves fully: `recognize_path` reveals as `(value: str | PathLike[Unknown], options: SearchParams | None = None) -> CoroutineType[Any, Any, Signature]`, and deliberate misuses (wrong argument type, misspelled method, unknown keyword) are still caught.

## The test

`pyo3` appends every name to the module's `__all__` as it is added — `add_class` goes through `add`, which maintains the index:
https://github.com/PyO3/pyo3/blob/v0.29.2/src/types/module.rs#L497-L502

So the extension's own `__all__` is the whole surface the Rust side declares, and the invariant needs no parsing and no new file: the package must export exactly that. `tests/test_init.py` asserts it, and runs on all three platforms in the existing `Test` job as well as locally.

It guards a failure that has already shipped. `1803d73` added `SearchParams` to `src/lib.rs` and to the stub without touching `__init__.py`; the export commit `5d00cd1` is not an ancestor of tag `1.1.0`. So 1.1.0 released a public class unreachable from the package root, corrected in 1.1.1 the next day — `git show 1.1.0:shazamio_core/__init__.py` prints five names of six.

## Not the `.pyi` drift

Whether `shazamio_core.pyi` agrees with the Rust module is a separate defect and is untouched here.

## How to test

```
pip install . && pytest
```

10 passed. Negative probe: delete a name from `__all__` and `tests/test_init.py` fails naming it.
