### PR TITLE
docs(ci): drop two comments that restate what the files already say

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,9 +29,6 @@ updates:
           - pyo3
           - pyo3-*
 
-  # `uv` has an ecosystem value of its own; poetry was served by `pip`, and keeping
-  #  that entry as well would point two ecosystems at one `pyproject.toml`.
-  #  https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-
   - package-ecosystem: uv
     directory: /
     schedule:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -55,9 +55,6 @@ jobs:
 
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
-      # The test dependencies come from `uv.lock` rather than from a second,
-      #  unversioned list written here, and `maturin` comes from
-      #  `build-system.requires`, so the extension is built without naming it twice.
       - name: Install the project and its test dependencies
         run: uv sync
 


### PR DESCRIPTION
Two comments that explain a decision nobody needs restated at the point of use.

- `.github/workflows/ci.yaml`: the note above the install step said the test dependencies come from `uv.lock` and `maturin` from `build-system.requires`. Both are visible in `pyproject.toml`, and the step is one line of `uv sync`.
- `.github/dependabot.yml`: the note above the `uv` entry explained why there is no `pip` entry beside it. The entry that is there says what is watched; the one that is not needs no epitaph.

No behaviour changes. Both files still parse, and the ecosystems Dependabot reads are unchanged: `github-actions`, `cargo`, `uv`.
