### PR TITLE
docs(readme): document the package, and declare the missing `[project]` metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,117 @@
 # shazamio-core
+
+Audio fingerprinting for Shazam, written in Rust and exposed to Python.
+
+It turns an audio file, or its bytes, into the signature Shazam's endpoint accepts. It does not talk to Shazam itself: [ShazamIO](https://github.com/shazamio/ShazamIO) is the client that sends the signature and reads the answer back.
+
+## Install
+
+```sh
+pip install shazamio-core
+```
+
+Or with [uv](https://docs.astral.sh/uv/):
+
+```sh
+uv add shazamio-core
+```
+
+Python 3.10 and newer. Prebuilt wheels:
+
+| Platform                                     | CPython 3.10+ (`abi3`) | PyPy 3.11 |
+|----------------------------------------------|------------------------|-----------|
+| Linux `x86_64`, `aarch64` (`manylinux_2_28`) | yes                    | yes       |
+| macOS `x86_64` (10.12+), `arm64` (11.0+)     | yes                    | no        |
+| Windows `win_amd64`, `win32`                 | yes                    | no        |
+
+Everything else builds from the source distribution and needs a Rust toolchain, 1.87 or newer.
+
+## Usage
+
+Both entry points are coroutines.
+
+```python
+import asyncio
+from pathlib import Path
+
+from shazamio_core import Recognizer
+
+
+async def main() -> None:
+    recognizer = Recognizer()
+
+    from_path = await recognizer.recognize_path("track.mp3")
+    from_bytes = await recognizer.recognize_bytes(Path("track.mp3").read_bytes())
+
+    print(from_path.signature.uri == from_bytes.signature.uri)
+
+
+asyncio.run(main())
+```
+
+`recognize_path` accepts a `str` or any `os.PathLike`.
+
+### What comes back
+
+Both return a `Signature`:
+
+| Field                                  | Meaning                                                                                                     |
+|----------------------------------------|-------------------------------------------------------------------------------------------------------------|
+| `signature.uri`                        | the fingerprint itself, base64 inside a `data:audio/vnd.shazam.sig` URI                                     |
+| `signature.samples`                    | duration of the analysed segment in milliseconds                                                            |
+| `signature.timestamp`                  | when the signature was produced                                                                             |
+| `timestamp`, `timezone`, `geolocation` | fixed values the request envelope carries. They are not read from the machine and mean nothing on their own |
+
+The URI is the part a client sends on:
+
+```
+data:audio/vnd.shazam.sig;base64,gCX+ypQoAnWcBQAAAJwRlAAAAAA...
+```
+
+### How much audio is analysed
+
+Ten seconds by default, taken from the middle of the file. A file shorter than the segment is used whole. Audio is converted to mono and downsampled to 16 kHz before analysis, whatever it started as.
+
+Set it per recognizer, or per call:
+
+```python
+recognizer = Recognizer(segment_duration_seconds=5)
+
+signature = await recognizer.recognize_path(
+    "track.mp3",
+    SearchParams(segment_duration_seconds=15),
+)
+```
+
+`SearchParams` wins where both are given.
+
+### Errors
+
+Audio that cannot be decoded, and a file that is not there, raise `SignatureError`:
+
+```python
+from shazamio_core import Recognizer, SignatureError
+
+try:
+    await Recognizer().recognize_path("not-audio.txt")
+except SignatureError as error:
+    print(error)
+```
+
+## Formats
+
+Decoding goes through [`rodio`](https://github.com/RustAudio/rodio) and `symphonia`, with the `flac`, `mp3`, `mp4`, `vorbis` and `wav` features enabled. The test suite covers MP3, Ogg Vorbis and FLAC on Linux, macOS and Windows.
+
+## Development
+
+```sh
+uv sync          # builds the extension and installs the test dependencies
+uv run pytest
+cargo test       # the Rust unit tests
+```
+
+`uv sync` needs a Rust toolchain; `maturin` comes from `pyproject.toml` and is fetched automatically.
+
+## License
+
+MIT. See [LICENSE](LICENSE).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,10 @@ build-backend = "maturin"
 
 [project]
 name = "shazamio_core"
+description = "Audio fingerprinting for Shazam, written in Rust and exposed to Python"
 readme = "README.md"
+license = "MIT"
+license-files = ["LICENSE"]
 authors = [{name = "dotX12", email = "dev@shitposting.team"}]
 maintainers = [{name = "Danipulok", email = "danipulok@gmail.com"}]
 # Must match the `abi3-py*` feature in `Cargo.toml`, which is where the floor is
@@ -33,6 +36,10 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
 dynamic = ["version"]
+
+[project.urls]
+Repository = "https://github.com/shazamio/shazamio-core"
+Issues = "https://github.com/shazamio/shazamio-core/issues"
 
 [tool.maturin]
 bindings = "pyo3"


### PR DESCRIPTION
## What

The `README` was one line, so both the repository front page and the PyPI page said nothing about what the package does. It now covers:

* what the package is, and what it is not: `ShazamIO` is the client that talks to Shazam, this one only produces the signature;
* installation, with the wheels that actually exist for `1.2.0`;
* both entry points, with a runnable example;
* the fields a `Signature` carries, including the three envelope values that are fixed constants rather than anything read from the machine;
* how much audio is analysed, and the two places that can change it;
* `SignatureError`;
* the decoders behind it, and how to build and test locally.

`[project]` in `pyproject.toml` declared no `description`, no `license` and no `urls`, so PyPI showed no summary, no licence and no link back to the repository. All three are declared now, the licence as an SPDX expression with `LICENSE` attached, which is what fills the sidebar.

## How to test

Every code example in the `README` was run against the built extension, and the wheel table lists the files published for `1.2.0` rather than the workflow's matrix.

The metadata is visible in the source distribution:

```sh
uv build --sdist --out-dir /tmp/sdist-check
tar xzOf /tmp/sdist-check/shazamio_core-1.2.0.tar.gz shazamio_core-1.2.0/PKG-INFO | head -15
```

```
Metadata-Version: 2.4
...
License-File: LICENSE
Summary: Audio fingerprinting for Shazam, written in Rust and exposed to Python
License-Expression: MIT
Project-URL: Issues, https://github.com/shazamio/shazamio-core/issues
Project-URL: Repository, https://github.com/shazamio/shazamio-core
```

`uv sync && uv run pytest` stays green.