### PR TITLE
fix(bindings): report `shazamio_core` as the module of every `#[pyclass]`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,7 +34,7 @@ fn shazamio_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
 }
 
 #[derive(Clone)]
-#[pyclass(from_py_object)]
+#[pyclass(from_py_object, module = "shazamio_core")]
 struct Recognizer {
     #[pyo3(get, set)]
     segment_duration_seconds: u32,

--- a/src/params.rs
+++ b/src/params.rs
@@ -2,7 +2,7 @@ use pyo3::{pyclass, pymethods};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[pyclass(from_py_object)]
+#[pyclass(from_py_object, module = "shazamio_core")]
 pub(crate) struct SearchParams {
     #[pyo3(get, set)]
     pub(crate) segment_duration_seconds: u32,

--- a/src/response.rs
+++ b/src/response.rs
@@ -2,7 +2,7 @@ use pyo3::{pyclass, pymethods, PyResult};
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Serialize, Deserialize)]
-#[pyclass(from_py_object)]
+#[pyclass(from_py_object, module = "shazamio_core")]
 pub(crate) struct Geolocation {
     #[pyo3(get)]
     pub(crate) altitude: i16,
@@ -13,7 +13,7 @@ pub(crate) struct Geolocation {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
-#[pyclass(from_py_object)]
+#[pyclass(from_py_object, module = "shazamio_core")]
 pub(crate) struct SignatureSong {
     #[pyo3(get)]
     pub(crate) samples: u32,
@@ -24,7 +24,7 @@ pub(crate) struct SignatureSong {
 }
 
 #[derive(Clone, Serialize, Deserialize)]
-#[pyclass(from_py_object)]
+#[pyclass(from_py_object, module = "shazamio_core")]
 pub(crate) struct Signature {
     #[pyo3(get)]
     pub(crate) geolocation: Geolocation,

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,3 +1,7 @@
+import sys
+
+import pytest
+
 import shazamio_core
 from shazamio_core import shazamio_core as extension
 
@@ -14,3 +18,22 @@ def test_package_exports_everything_the_extension_declares() -> None:
     #  extension's list is the whole surface the Rust side declares.
     #  https://github.com/PyO3/pyo3/blob/v0.29.2/src/types/module.rs#L497-L502
     assert sorted(shazamio_core.__all__) == sorted(extension.__all__)
+
+
+@pytest.mark.parametrize("name", sorted(shazamio_core.__all__))
+def test_every_public_name_reports_the_package_as_its_module(name: str) -> None:
+    """`__module__` is an import path, and `repr` and `pickle` both read it as one.
+
+    `pyo3` builds `tp_name` from the `module` argument of `#[pyclass]` and falls back
+    to `builtins`, which every class here used to inherit, so `repr()` read
+    `<builtins.Geolocation object at 0x...>` and `pickle` could not name the class.
+    https://github.com/PyO3/pyo3/blob/v0.29.2/src/pyclass/create_type_object.rs#L610-L616
+    """
+    declared = getattr(shazamio_core, name)
+
+    assert declared.__module__ == shazamio_core.__name__
+
+    # What the attribute is for: the path has to lead back to this exact object, which
+    #  is how `pickle` resolves a class it has only the name of. Pickling also needs a
+    #  `__getnewargs__`, which nothing here declares yet.
+    assert getattr(sys.modules[declared.__module__], declared.__qualname__) is declared


### PR DESCRIPTION
## What

Every `#[pyclass]` in the crate omitted `module`, so `pyo3` fell back to
`builtins` when building `tp_name`:

```
>>> import shazamio_core
>>> shazamio_core.Geolocation.__module__
'builtins'
>>> shazamio_core.Geolocation(1, 2, 3)
<builtins.Geolocation object at 0x7add61693a90>
```

All five now declare `module = "shazamio_core"`, and report it.

## Why that value

`src/errors.rs` already names the package root:
`create_exception!(shazamio_core, SignatureError, PyException)`. Pointing the
classes at `shazamio_core.shazamio_core` instead would leave five of the six
public names reporting one module and the sixth another, and that submodule is
the private path the package re-exports from, which `pyright` flags as
`reportPrivateImportUsage` for anyone who imports it directly.

`__module__` is an import path, not a label: `pickle` resolves a class by
looking its name up in that module. Both candidates resolve here, because
`shazamio_core/__init__.py` re-exports all six names, so the tie is broken by
which path users are meant to type.

This is a prerequisite for pickling, not the whole of it. `pickle.dumps` still
fails, now with `TypeError: cannot pickle 'shazamio_core.Geolocation' object` --
the classes carry no `__getnewargs__`, which is a separate change.

## How to test

```sh
uv sync
uv run pytest
uv run python -m mypy.stubtest shazamio_core.shazamio_core
cargo test
```

`tests/test_init.py` gains a case per public name: `__module__` names the
package, and the path leads back to the same object.

Note for running `cargo test` locally: the test target links `libpython`, so it
needs an interpreter built `--enable-shared`. If the system one is not, point
`PYO3_PYTHON` and `LD_LIBRARY_PATH` at one that is. CI already uses such a build.
