### PR TITLE
build(justfile): run every CI command through a `just` recipe

### DIFF
--- a/.github/actions/setup-just/action.yml
+++ b/.github/actions/setup-just/action.yml
@@ -7,8 +7,10 @@ runs:
     - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
     # The version is pinned rather than left to float, so a `just` release cannot turn
-    #  CI red on its own. Dependabot bumps the two action pins here but not this
-    #  version, which is an input rather than a `uses:`, so a new `just` is taken by hand.
+    #  CI red on its own. Dependabot bumps the two action pins here but not this one: its
+    #  parser collects `uses:` values and reads no `with:` block at all, so a new `just`
+    #  is taken by hand.
+    #  https://github.com/dependabot/dependabot-core/blob/9eb8675fc93584540fcde661811d38507bb9458b/github_actions/lib/dependabot/github_actions/file_parser.rb#L59
     - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
       with:
         just-version: "1.58.0"

--- a/.github/actions/setup-just/action.yml
+++ b/.github/actions/setup-just/action.yml
@@ -1,0 +1,16 @@
+name: Set up `just`
+description: Install `uv` and the `just` runner, and put `just` on `PATH`.
+
+runs:
+  using: composite
+  steps:
+    - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
+
+    # On PyPI `just` is `rust-just`; the name `just` there is an unrelated package.
+    #  The version is exact so every runner gets the same one, and nothing bumps it:
+    #  Dependabot reads `uses:` and lockfiles, never a version inside a `run:`.
+    #  https://pypi.org/project/rust-just/
+    - shell: bash
+      run: |
+        uv tool install rust-just==1.58.0
+        uv tool dir --bin >> "$GITHUB_PATH"

--- a/.github/actions/setup-just/action.yml
+++ b/.github/actions/setup-just/action.yml
@@ -1,16 +1,14 @@
 name: Set up `just`
-description: Install `uv` and the `just` runner, and put `just` on `PATH`.
+description: Install `uv` and the `just` runner.
 
 runs:
   using: composite
   steps:
     - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
-    # On PyPI `just` is `rust-just`; the name `just` there is an unrelated package.
-    #  The version is exact so every runner gets the same one, and nothing bumps it:
-    #  Dependabot reads `uses:` and lockfiles, never a version inside a `run:`.
-    #  https://pypi.org/project/rust-just/
-    - shell: bash
-      run: |
-        uv tool install rust-just==1.58.0
-        uv tool dir --bin >> "$GITHUB_PATH"
+    # The version is pinned rather than left to float, so a `just` release cannot turn
+    #  CI red on its own. Dependabot bumps the two action pins here but not this
+    #  version, which is an input rather than a `uses:`, so a new `just` is taken by hand.
+    - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
+      with:
+        just-version: "1.58.0"

--- a/.github/actions/setup-just/action.yml
+++ b/.github/actions/setup-just/action.yml
@@ -6,11 +6,9 @@ runs:
   steps:
     - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
-    # The version is pinned rather than left to float, so a `just` release cannot turn
-    #  CI red on its own. Dependabot bumps the two action pins here but not this one: its
-    #  parser collects `uses:` values and reads no `with:` block at all, so a new `just`
-    #  is taken by hand.
-    #  https://github.com/dependabot/dependabot-core/blob/9eb8675fc93584540fcde661811d38507bb9458b/github_actions/lib/dependabot/github_actions/file_parser.rb#L59
+    # No version: upstream promises no release breaks an existing `justfile` and that
+    #  there will never be a `just` 2.0, so a pin could only strand us on a version
+    #  carrying a bug, with nothing to bump it. `just --fmt` is the one carve-out from
+    #  that promise, and no recipe here calls it.
+    #  https://github.com/casey/just/blob/7f4ef81bd6a93faa2b28430912c8e9ab0e3dd29a/README.md#L501
     - uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 # v4
-      with:
-        just-version: "1.58.0"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,13 @@ updates:
   # Without this the SHA pins in `ci.yaml` freeze: nothing else in the repository
   #  reads them, so an action stays on whatever commit it was pinned to the day it
   #  was written. Dependabot rewrites both the SHA and the version comment beside it.
+  #  `/` reaches `.github/workflows` and a root `action.yml` and nothing deeper, so
+  #  the actions we write ourselves are named separately; only `directories` globs.
+  #  https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#directories-or-directory--
   - package-ecosystem: github-actions
-    directory: /
+    directories:
+      - /
+      - /.github/actions/*
     schedule:
       interval: monthly
     commit-message:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,10 +36,9 @@ env:
   MATURIN_VERSION: v1.14.1
 
 # Every command below lives in the `justfile`, so a local check and a CI job are one
-#  string rather than two copies that drift. `just` is a Rust binary no runner ships;
-#  it is on PyPI as `rust-just`, and installing it with `uv` keeps it off the list of
-#  pinned actions above: there is no third-party action here to grant `contents:
-#  write` to.
+#  string rather than two copies that drift. Four jobs need `just`, so getting it is
+#  a local composite action rather than four copies of the same two commands:
+#  `.github/actions/setup-just`.
 
 jobs:
   # Builds its own wheel rather than taking one from `linux`: the goldens are a claim
@@ -59,12 +58,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-
-      - name: Install `just`
-        run: |
-          uv tool install rust-just
-          uv tool dir --bin >> "$GITHUB_PATH"
+      - uses: ./.github/actions/setup-just
 
       - name: Install the project and its test dependencies
         run: just sync
@@ -95,12 +89,7 @@ jobs:
         with:
           python-version: "3.x"
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-
-      - name: Install `just`
-        run: |
-          uv tool install rust-just
-          uv tool dir --bin >> "$GITHUB_PATH"
+      - uses: ./.github/actions/setup-just
 
       - name: Run the unit tests
         run: just rust-test
@@ -118,12 +107,7 @@ jobs:
 
       - run: rustup component add rustfmt clippy
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-
-      - name: Install `just`
-        run: |
-          uv tool install rust-just
-          uv tool dir --bin >> "$GITHUB_PATH"
+      - uses: ./.github/actions/setup-just
 
       - name: Check the formatting and run `clippy`
         run: just lint
@@ -294,12 +278,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
-
-      - name: Install `just`
-        run: |
-          uv tool install rust-just
-          uv tool dir --bin >> "$GITHUB_PATH"
+      - uses: ./.github/actions/setup-just
 
       - name: Check the crate against the declared MSRV
         run: just msrv

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,12 @@ permissions:
 env:
   MATURIN_VERSION: v1.14.1
 
+# Every command below lives in the `justfile`, so a local check and a CI job are one
+#  string rather than two copies that drift. `just` is a Rust binary no runner ships;
+#  it is on PyPI as `rust-just`, and installing it with `uv` keeps it off the list of
+#  pinned actions above: there is no third-party action here to grant `contents:
+#  write` to.
+
 jobs:
   # Builds its own wheel rather than taking one from `linux`: the goldens are a claim
   #  about the algorithm, and the claim has to hold on every platform the wheels
@@ -55,19 +61,22 @@ jobs:
 
       - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
+      - name: Install `just`
+        run: |
+          uv tool install rust-just
+          uv tool dir --bin >> "$GITHUB_PATH"
+
       - name: Install the project and its test dependencies
-        run: uv sync
+        run: just sync
 
       - name: Run the tests
-        run: uv run pytest
+        run: just test
 
-      # Nothing else compares the hand-written `.pyi` with the extension, and it had
-      #  drifted: `Recognizer.__init__` declared a parameter the runtime carries on
-      #  `__new__`, and three classes claimed to be `@dataclass`. The stub does not
-      #  vary by platform, so one runner answers for all three.
+      # The stub does not vary by platform, so one runner answers for all three. Why
+      #  the check exists at all: the `stubtest` recipe.
       - name: Check the type stub against the built extension
         if: matrix.os == 'ubuntu-latest'
-        run: uv run python -m mypy.stubtest shazamio_core.shazamio_core
+        run: just stubtest
 
   # Byte layout, checksum, band ordering: none of that varies by platform, so one
   #  runner answers for all of them -- whether the fingerprint itself does is what
@@ -80,20 +89,27 @@ jobs:
 
       # The test binary is an executable rather than an extension module, so it
       #  links `libpython` instead of borrowing the loader's symbols, and needs an
-      #  interpreter built `--enable-shared` -- which is what this action ships.
+      #  interpreter built `--enable-shared`, which is what this action ships.
       #  https://github.com/actions/python-versions/blob/c2033aa6c313f068f4bde238bfaa5987ad4f2e79/builders/ubuntu-python-builder.psm1#L37
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
 
-      - name: Run the unit tests
-        run: cargo test
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
-  # Neither gate below is provided by anything else here: the wheel jobs compile the
-  #  crate, and a compiler is indifferent to formatting and to every lint `clippy`
-  #  adds on top of it. `clippy` runs at its own default level rather than with a
-  #  curated lint set -- this is a gate against new findings, not a rewrite of code
-  #  that predates it.
+      - name: Install `just`
+        run: |
+          uv tool install rust-just
+          uv tool dir --bin >> "$GITHUB_PATH"
+
+      - name: Run the unit tests
+        run: just rust-test
+
+  # Neither of the two gates the recipe runs is provided by anything else here: the
+  #  wheel jobs compile the crate, and a compiler is indifferent to formatting and to
+  #  every lint `clippy` adds on top of it. `clippy` runs at its own default level
+  #  rather than with a curated lint set: it is a gate against new findings, not a
+  #  rewrite of code that predates it.
   lint:
     name: Rust lint
     runs-on: ubuntu-latest
@@ -102,14 +118,15 @@ jobs:
 
       - run: rustup component add rustfmt clippy
 
-      - name: Check the formatting
-        run: cargo fmt --all --check
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
-      # `--all-targets` is what reaches the `#[cfg(test)]` modules. The default target
-      #  set stops at the library, so every unit test would go unlinted.
-      #  https://doc.rust-lang.org/cargo/commands/cargo-clippy.html#target-selection
-      - name: Run `clippy`
-        run: cargo clippy --all-targets -- -D warnings
+      - name: Install `just`
+        run: |
+          uv tool install rust-just
+          uv tool dir --bin >> "$GITHUB_PATH"
+
+      - name: Check the formatting and run `clippy`
+        run: just lint
 
   # The wheels below are abi3: one per platform, loading on every CPython from 3.10
   #  up. There is no per-interpreter matrix any more, so a new CPython release
@@ -269,24 +286,23 @@ jobs:
           name: wheels-sdist
           path: dist
 
-  # `rust-version` in `Cargo.toml` is a claim nothing else checks: every other job
-  # installs current stable, so a `cargo update` can raise the real floor and stay
-  # green. Whoever builds the sdist on a distro toolchain is the one who finds out.
+  # `rust-version` in `Cargo.toml` is a claim nothing else checks, because every
+  #  other job installs current stable. Why that matters: the `msrv` recipe.
   msrv:
     name: MSRV
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      # Read from `Cargo.toml` rather than restated here: a second copy would drift
-      # and leave the job checking a floor the crate no longer declares.
-      - name: Read the declared MSRV
-        id: declared
-        run: echo "version=$(grep -oP '^rust-version = "\K[^"]+' Cargo.toml)" >> "$GITHUB_OUTPUT"
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
 
-      - run: rustup toolchain install ${{ steps.declared.outputs.version }} --profile minimal
+      - name: Install `just`
+        run: |
+          uv tool install rust-just
+          uv tool dir --bin >> "$GITHUB_PATH"
 
-      - run: cargo +${{ steps.declared.outputs.version }} check --locked --all-targets
+      - name: Check the crate against the declared MSRV
+        run: just msrv
 
   release:
     name: Release

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ just sync        # builds the extension and installs the test dependencies
 just all         # everything CI gates on
 ```
 
-`just sync` needs a Rust toolchain; `maturin` comes from `pyproject.toml` and is fetched automatically. `just` itself is on PyPI, so `uv tool install rust-just` is one way to get it.
+`just sync` needs a Rust toolchain; `maturin` comes from `pyproject.toml` and is fetched automatically. `just` itself is packaged for most systems, listed under [Packages](https://github.com/casey/just#packages).
 
 `just rust-test` links `libpython`, so on Debian and Ubuntu the development package of the interpreter `cargo` picks up has to be present, or the build stops at `rust-lld: error: unable to find library -lpython3.14`:
 

--- a/README.md
+++ b/README.md
@@ -104,13 +104,21 @@ Decoding goes through [`rodio`](https://github.com/RustAudio/rodio) and `symphon
 
 ## Development
 
+Every check CI runs is a [`just`](https://github.com/casey/just) recipe, so the two cannot drift apart:
+
 ```sh
-uv sync          # builds the extension and installs the test dependencies
-uv run pytest
-cargo test       # the Rust unit tests
+just --list      # what there is
+just sync        # builds the extension and installs the test dependencies
+just all         # everything CI gates on
 ```
 
-`uv sync` needs a Rust toolchain; `maturin` comes from `pyproject.toml` and is fetched automatically.
+`just sync` needs a Rust toolchain; `maturin` comes from `pyproject.toml` and is fetched automatically. `just` itself is on PyPI, so `uv tool install rust-just` is one way to get it.
+
+`just rust-test` links `libpython`, so on Debian and Ubuntu the development package of the interpreter `cargo` picks up has to be present, or the build stops at `rust-lld: error: unable to find library -lpython3.14`:
+
+```sh
+sudo apt install libpython3.14-dev
+```
 
 ## License
 

--- a/justfile
+++ b/justfile
@@ -1,0 +1,60 @@
+# The one home of every command this project runs. A CI job and a local check are
+#  the same string here rather than two copies that drift apart.
+
+# `bash` on all three CI runners and on a developer machine, so a recipe behaves
+#  the same everywhere. The default is `sh`, which on Windows is whatever Git
+#  happens to have put on `PATH`.
+set shell := ["bash", "-uc"]
+
+[doc("Show the recipes")]
+default:
+    @just --list
+
+[doc("Build the extension into the environment and install the test dependencies")]
+sync:
+    uv sync
+
+[doc("Run the Python test suite")]
+test:
+    uv run pytest
+
+# Nothing else compares the hand-written `.pyi` with the extension, and it had
+#  drifted: `Recognizer.__init__` declared a parameter the runtime carries on
+#  `__new__`, and three classes claimed to be `@dataclass`.
+[doc("Check the type stub against the built extension")]
+stubtest:
+    uv run python -m mypy.stubtest shazamio_core.shazamio_core
+
+[doc("Run the Rust unit tests")]
+rust-test:
+    cargo test
+
+[doc("Reformat the crate")]
+fmt:
+    cargo fmt --all
+
+# `--all-targets` is what reaches the `#[cfg(test)]` modules. The default target
+#  set stops at the library, so every unit test would go unlinted.
+#  https://doc.rust-lang.org/cargo/commands/cargo-clippy.html#target-selection
+[doc("Check the formatting and run `clippy`")]
+lint:
+    cargo fmt --all --check
+    cargo clippy --all-targets -- -D warnings
+
+# Everything else builds with current stable, so a `cargo update` can raise the
+#  real floor and stay green. Whoever builds the sdist on a distro toolchain is
+#  the one who finds out.
+[doc("Check the crate against the Rust version it declares")]
+msrv:
+    #!/usr/bin/env bash
+    set -euo pipefail
+
+    # Read from `Cargo.toml` rather than restated here: a second copy would drift
+    #  and leave the check running against a floor the crate no longer declares.
+    version="$(sed -n 's/^rust-version = "\(.*\)"/\1/p' Cargo.toml)"
+
+    rustup toolchain install "$version" --profile minimal
+    cargo "+$version" check --locked --all-targets
+
+[doc("Everything CI gates on; the first run downloads the MSRV toolchain")]
+all: lint rust-test test stubtest msrv


### PR DESCRIPTION
## What

Every command CI runs now lives in a `justfile`, and each job invokes the recipe
instead of restating the command. A contributor gets the same checks locally:

```
$ just --list
Available recipes:
    all       # Everything CI gates on; the first run downloads the MSRV toolchain
    default   # Show the recipes
    fmt       # Reformat the crate
    lint      # Check the formatting and run `clippy`
    msrv      # Check the crate against the Rust version it declares
    rust-test # Run the Rust unit tests
    stubtest  # Check the type stub against the built extension
    sync      # Build the extension into the environment and install the test dependencies
    test      # Run the Python test suite
```

The MSRV job is the case that shows why. It used to re-implement, in YAML, the
reading of `rust-version` out of `Cargo.toml`, and nothing local could run it:

```yaml
- name: Read the declared MSRV
  id: declared
  run: echo "version=$(grep -oP '^rust-version = "\K[^"]+' Cargo.toml)" >> "$GITHUB_OUTPUT"
- run: rustup toolchain install ${{ steps.declared.outputs.version }} --profile minimal
- run: cargo +${{ steps.declared.outputs.version }} check --locked --all-targets
```

```yaml
- name: Check the crate against the declared MSRV
  run: just msrv
```

Four jobs need `just` on the runner, so installing it is one composite action at
`.github/actions/setup-just` rather than four copies of the same steps. It takes
`just` from the project's own releases and does not pin a version: upstream
commits to never breaking an existing `justfile` and to never shipping a `just`
2.0, so a pin could only strand us on a version carrying a bug.

`dependabot.yml` needed a matching change. The `github-actions` ecosystem with
`directory: /` reaches `.github/workflows` and a root `action.yml` and nothing
below that, so the action pins inside `.github/actions/` would have frozen at
whatever commit they were written against. Only `directories` accepts a glob.

## Why

A CI job and a local check were two copies of the same command with nothing
holding them together. Contributors also had no way to run what CI gates on
before pushing.

## How to test

```
$ just all
test result: ok. 27 passed; 0 failed        # cargo test
16 passed in 0.37s                          # pytest
Success: no issues found in 1 module        # stubtest
1.87-x86_64-unknown-linux-gnu unchanged     # msrv
```

`just rust-test` links `libpython`, so on Debian and Ubuntu the interpreter's
development package has to be installed first; the README now says so.
