### PR TITLE
ci(cache): give each `linux` matrix entry its own buildx cache scope

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -206,14 +206,19 @@ jobs:
           tags: shazamio_core
           push: false
           load: true
-          cache-from: type=gha
+          # Both matrix entries share the buildx default scope otherwise, so the
+          #  repository holds one index and whichever job finishes last on `master`
+          #  overwrites the other's. One run measured 12 cached layers on x86 against 0
+          #  on ARM64, and 8.72 GB of blobs behind four surviving indexes.
+          #  https://github.com/moby/buildkit/blob/703866e5f2e4af295b485b181b447a7755d5099c/README.md#L544
+          cache-from: type=gha,scope=${{ matrix.name }}
           # A pull request's cache is scoped to `refs/pull/N/merge`, which neither `master`
           #  nor another pull request can read, so each one exported a full image of layers
           #  nobody could reuse. That held the repository over the 10 GB limit, and eviction
           #  is oldest-first, so the x86 image lost its layers before the next run read them
           #  -- 0 cached layers, and 224s of a 441s build step spent re-exporting them.
           #  https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching
-          cache-to: ${{ github.ref == 'refs/heads/master' && 'type=gha,mode=max' || '' }}
+          cache-to: ${{ github.ref == 'refs/heads/master' && format('type=gha,mode=max,scope={0}', matrix.name) || '' }}
           context: .
 
       - name: List /opt/dist directory


### PR DESCRIPTION
## What

`scope` on `type=gha` defaults to `buildkit`, so both entries of the `linux` matrix write and read one cache index. Whichever job finishes last on `master` overwrites the other's, and the next run finds layers built for the wrong architecture.

Two images, one index key:

```
$ gh api 'repos/{owner}/{repo}/actions/caches?per_page=100' \
    --jq '.actions_caches[] | select(.key|startswith("index-buildkit")) | "\(.key)  \(.ref)"'
index-buildkit-1-49c8f7d5#46  refs/heads/master
index-buildkit-1-49c8f7d5#45  refs/heads/master
```

`#45` and `#46` are two buildkit revisions of the same index, not two scopes: the hash is the same because the scope is.

What that costs, read off the two build steps of one run:

```
linux (manylinux-x86)  12 CACHED layers   19:59:02 -> 20:00:29  (1m27s)
linux (manylinux-arm)   0 CACHED layers   19:59:02 -> 20:02:17  (3m15s)
```

Both jobs imported a manifest; only one of them found layers behind it.

With `scope=${{ matrix.name }}` each image gets its own index and neither can overwrite the other. `cache-to` keeps the `master` gate it already had, so a pull request still exports nothing.

**This does not fix the quota, and is not meant to.** The repository sits above the 10 GB limit, so GitHub is evicting oldest-first regardless:

```
$ gh api repos/{owner}/{repo}/actions/cache/usage
{"active_caches_size_in_bytes":11936616595,"active_caches_count":808}
```

Two scopes will hold more than one did, not less. What changes here is that the ARM64 job stops missing on every single run; getting back under the limit is separate work.

## Why

`buildkit` is the documented default for `scope`, and nothing in the matrix overrode it:
https://github.com/moby/buildkit/blob/703866e5f2e4af295b485b181b447a7755d5099c/README.md#L544

## How to test

Once this is on `master` and two runs have gone through, both index keys should be present with different hashes, and neither `linux` job should report `0` cached layers on a subsequent run.
