### PR TITLE
ci(paths): run each job only when something it gates on changed

### DIFF
--- a/.github/path-filters.yaml
+++ b/.github/path-filters.yaml
@@ -1,0 +1,43 @@
+# Which paths gate which check. `.github/workflows/ci.yaml` reads these outputs;
+#  `.pre-commit-config.yaml` restates the same sets as `re` patterns, because
+#  neither format can read the other.
+#  https://github.com/dorny/paths-filter/blob/ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d/README.md#L115
+
+# Whatever decides is in every set below: a change to the workflow, to this file
+#  or to a recipe runs the whole matrix, rather than the part an older decision
+#  happened to select.
+harness: &harness
+  - .github/workflows/ci.yaml
+  - .github/actions/**
+  - .github/path-filters.yaml
+  - justfile
+
+crate: &crate
+  - src/**
+  - Cargo.toml
+  - Cargo.lock
+
+# An alias to a list nests it, and this action flattens that.
+#  https://github.com/dorny/paths-filter/blob/ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d/README.md#L475
+
+# `Rust lint`, `Rust unit tests` and `MSRV`.
+rust:
+  - *harness
+  - *crate
+
+# `Test`, which runs `just test` and `just stubtest`. The crate is in scope
+#  because both exercise the built extension rather than the sources beside it.
+python:
+  - *harness
+  - *crate
+  - tests/**
+  - shazamio_core/**
+  - pyproject.toml
+  - uv.lock
+
+# `windows`, `macos`, `linux` and `sdist`, which build what a release publishes.
+dist:
+  - *harness
+  - *crate
+  - pyproject.toml
+  - docker/**

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,11 +41,42 @@ env:
 #  `.github/actions/setup-just`.
 
 jobs:
+  # A `paths:` filter on the trigger skips the whole workflow, and a required check
+  #  belonging to a run that never happened stays pending forever. A job skipped by
+  #  `if:` reports `skipped`, which counts as success, so the gate lives here.
+  #  https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks
+  changes:
+    name: Changed paths
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      # The workflow grants three scopes, which sets every other one to `none`, and
+      #  this action reads the pull request's file list through the API.
+      #  https://github.com/dorny/paths-filter/blob/ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d/README.md#L23
+      pull-requests: read
+    outputs:
+      rust: ${{ steps.filter.outcome == 'skipped' || steps.filter.outputs.rust == 'true' }}
+      python: ${{ steps.filter.outcome == 'skipped' || steps.filter.outputs.python == 'true' }}
+      dist: ${{ steps.filter.outcome == 'skipped' || steps.filter.outputs.dist == 'true' }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # A tag push carries no diff to filter on, and `workflow_dispatch` is somebody
+      #  asking for the whole matrix. The step then does not run and leaves its
+      #  outputs empty, which the three above read as `true`.
+      - id: filter
+        if: github.event_name != 'workflow_dispatch' && !startsWith(github.ref, 'refs/tags/')
+        uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        with:
+          filters: .github/path-filters.yaml
+
   # Builds its own wheel rather than taking one from `linux`: the goldens are a claim
   #  about the algorithm, and the claim has to hold on every platform the wheels
   #  target. `release` waits on this job, so a changed fingerprint stops a publish.
   test:
     name: Test (${{ matrix.os }})
+    needs: changes
+    if: needs.changes.outputs.python == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -77,6 +108,8 @@ jobs:
   #  the job above exists for.
   rust-test:
     name: Rust unit tests
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -101,6 +134,8 @@ jobs:
   #  rewrite of code that predates it.
   lint:
     name: Rust lint
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -116,6 +151,8 @@ jobs:
   #  up. There is no per-interpreter matrix any more, so a new CPython release
   #  needs no change here and no new release. The floor lives in `Cargo.toml`.
   windows:
+   needs: changes
+   if: needs.changes.outputs.dist == 'true'
    runs-on: windows-latest
    strategy:
      matrix:
@@ -146,6 +183,8 @@ jobs:
          path: dist
 #
   macos:
+    needs: changes
+    if: needs.changes.outputs.dist == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -175,6 +214,8 @@ jobs:
           path: dist
 
   linux:
+    needs: changes
+    if: needs.changes.outputs.dist == 'true'
     strategy:
       matrix:
         include:
@@ -260,6 +301,8 @@ jobs:
           path: dist
 
   sdist:
+    needs: changes
+    if: needs.changes.outputs.dist == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -279,6 +322,8 @@ jobs:
   #  other job installs current stable. Why that matters: the `msrv` recipe.
   msrv:
     name: MSRV
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,9 +26,12 @@ repos:
       - id: name-tests-test
         args: [--pytest-test-first]
 
-  # Each hook below is one of the gating jobs in `.github/workflows/ci.yaml`,
-  #  calling the same recipe that job calls. Its `files:` regex is what keeps a
-  #  commit from paying for a check nothing in it could have broken.
+  # Each hook runs the recipe its namesake job in `.github/workflows/ci.yaml` runs,
+  #  over the same paths: the `rust` and `python` sets of
+  #  `.github/path-filters.yaml`, which neither format can read from the other.
+
+  # Deliberately not identical to that file: each config lists whatever decides for
+  #  it, so the workflow carries `.github/**` and this one carries itself.
   - repo: local
     hooks:
       - id: lint
@@ -36,7 +39,7 @@ repos:
         entry: just
         args: [lint]
         language: system
-        files: ^(src/.*\.rs|Cargo\.(toml|lock))$
+        files: ^(\.pre-commit-config\.yaml|justfile|src/.*|Cargo\.(toml|lock))$
         pass_filenames: false
 
       - id: rust-test
@@ -44,7 +47,7 @@ repos:
         entry: just
         args: [rust-test]
         language: system
-        files: ^(src/.*\.rs|Cargo\.(toml|lock))$
+        files: ^(\.pre-commit-config\.yaml|justfile|src/.*|Cargo\.(toml|lock))$
         pass_filenames: false
 
       # On the lockfile as well as on the crate: what a `cargo update` can do to
@@ -54,17 +57,17 @@ repos:
         entry: just
         args: [msrv]
         language: system
-        files: ^(src/.*\.rs|Cargo\.(toml|lock))$
+        files: ^(\.pre-commit-config\.yaml|justfile|src/.*|Cargo\.(toml|lock))$
         pass_filenames: false
 
-      # The Rust sources are in scope because the tests exercise the built
-      #  extension; `tool.uv.cache-keys` in `pyproject.toml` is what rebuilds it.
+      # The crate is in scope for both because they exercise the built extension;
+      #  `tool.uv.cache-keys` in `pyproject.toml` is what rebuilds it.
       - id: test
         name: python · pytest
         entry: just
         args: [test]
         language: system
-        files: ^(src/.*\.rs|tests/.*|Cargo\.(toml|lock)|pyproject\.toml|uv\.lock)$
+        files: ^(\.pre-commit-config\.yaml|justfile|src/.*|Cargo\.(toml|lock)|tests/.*|shazamio_core/.*|pyproject\.toml|uv\.lock)$
         pass_filenames: false
 
       - id: stubtest
@@ -72,5 +75,5 @@ repos:
         entry: just
         args: [stubtest]
         language: system
-        files: ^(src/.*\.rs|shazamio_core/.*|Cargo\.(toml|lock)|pyproject\.toml)$
+        files: ^(\.pre-commit-config\.yaml|justfile|src/.*|Cargo\.(toml|lock)|tests/.*|shazamio_core/.*|pyproject\.toml|uv\.lock)$
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ just install     # builds the extension, installs the test dependencies and the 
 just all         # everything CI gates on
 ```
 
-`just install` also wires the same recipes into `git commit` through [`pre-commit`](https://pre-commit.com), each one scoped to the files it gates, so a change to the `README` runs none of them and a change to the crate runs all of them.
+`just install` also wires the same recipes into `git commit` through [`pre-commit`](https://pre-commit.com), each one scoped to the files it gates, so a change to the `README` runs none of them and a change to the crate runs all of them. CI scopes its jobs the same way, from the same sets: `.github/path-filters.yaml`.
 
 `just install` needs a Rust toolchain; `maturin` comes from `pyproject.toml` and is fetched automatically. `just` itself is packaged for most systems, listed under [Packages](https://github.com/casey/just#packages).
 


### PR DESCRIPTION
## What

Every push and every pull request ran the whole matrix: thirteen jobs, two of them
wheel builds under QEMU. A change touching only `README.md` cost the same as one
rewriting the crate.

Each job now declares what it can be broken by. `.github/path-filters.yaml` holds
three sets of paths, a `changes` job evaluates them once, and every other job
carries `needs: changes` and an `if:` on the set it belongs to.

Which set a change lands in, run through the matcher the action itself uses
(`picomatch@2.3.1` with `dot: true`):

```
changed                   rust    python  dist
README.md only            false   false   false
LICENSE + .gitignore      false   false   false
dependabot.yml only       false   false   false
pre-commit config only    false   false   false
a crate source            true    true    true
a test only               false   true    false
the stub only             false   true    false
pyproject only            false   true    true
uv.lock only              false   true    false
a Dockerfile              false   false   true
the workflow itself       true    true    true
the filter file itself    true    true    true
the composite action      true    true    true
the justfile              true    true    true
```

So a `README` change starts one job instead of thirteen, and a change under
`tests/` starts three: the four jobs that build wheels, two of them under QEMU,
no longer run for it.

The last four rows are the rule that keeps this honest. Whatever decides is in
every set, so an edit to the workflow, to the filter file, to the composite action
or to a recipe runs the whole matrix rather than the part an older decision would
have selected.

## Why the filter is per job, not on the trigger

`paths:` on `push` and `pull_request` is the shorter way to write this and it is
the wrong one. A workflow skipped by a path filter creates no check runs at all,
so a required check belonging to it stays pending and blocks the merge for good:

> If a workflow is skipped due to path filtering, branch filtering or a commit
> message, then checks associated with that workflow will remain in a "Pending"
> state. […] You should not use path or branch filtering to skip workflow runs if
> the workflow is required to pass before merging.

A job skipped by `if:` reports a conclusion, and that conclusion counts as a pass:

> Successful check statuses are `success`, `skipped`, and `neutral`.

https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks

Nothing is a required check on `master` today, so neither shape breaks anything
right now. The difference only shows up the day branch protection is turned on,
which is a bad day to discover it.

## Releases are unaffected

A tag push carries no diff to filter on, and `workflow_dispatch` is somebody
asking for the whole matrix, so on both the filter step does not run at all: it
leaves its outputs empty and the job reads them as "changed". `release` waits on
seven jobs, and all seven still run for a tag.

## The commit hooks moved with it

The `files:` regexes in `.pre-commit-config.yaml` now restate the same `rust` and
`python` sets, so a hook and the job of the same name cover the same paths instead
of two lists that drift. Neither format can read the other, so the filter file is
the one that carries the reasoning and the regexes point at it.

They are deliberately not identical in one respect: each config includes whatever
decides for it, so the workflow lists `.github/**` and the hook config lists
itself.

## How to test

Open a pull request that touches only `README.md`: `Changed paths` runs, every
other job reports `skipped`. Push a change under `src/` and everything runs.
Locally, `pre-commit run --files <path>` prints which hooks a given change would
run.
