### PR TITLE
docs(readme): say that `recognize_path` takes an `os.PathLike[str]`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ async def main() -> None:
 asyncio.run(main())
 ```
 
-`recognize_path` accepts a `str` or any `os.PathLike`.
+`recognize_path` accepts a `str` or an `os.PathLike[str]`. A `__fspath__` returning `bytes` is rejected.
 
 ### What comes back
 


### PR DESCRIPTION
## What

The `README` said `recognize_path` accepts "a `str` or any `os.PathLike`". The
stub declares `str | PathLike[str]`, and the extension enforces that:

```python
class BytesPath(os.PathLike):
    def __fspath__(self) -> bytes:
        return b"tests/data/probe.flac"

await Recognizer().recognize_path(BytesPath())
```
```
TypeError: 'bytes' object is not an instance of 'str'
```

A `str` path is fine, and is what the sentence now describes:

```
data:audio/vnd.shazam.sig;base64,gCX+ypQoAnW...
```

## Why this is a pull request of its own

It touches nothing but `README.md`, which is the case the path filters added in
the previous change are meant to skip entirely. This is the check on that: only
`Changed paths` should run, and the other thirteen jobs should report `skipped`
rather than starting or sitting pending.
