### PR TITLE
build(deps): restore the `maturin` floor and stop bumping it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -49,3 +49,9 @@ updates:
     commit-message:
       prefix: build
       include: scope
+    # `maturin` is the build backend, not a dependency: the floor in
+    #  `build-system.requires` has its reason beside it, and Dependabot raised it to
+    #  whatever was newest. `MATURIN_VERSION` in `workflows/ci.yaml` is the pin.
+    #  https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/controlling-dependencies-updated
+    ignore:
+      - dependency-name: maturin

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ lint = [
 #  feature dropped the link to `libpython`, which broke `cargo test`. `maturin`
 #  1.9.4 is the first release that turns extension-module linking on by itself.
 #  https://pyo3.rs/v0.29.0/faq.html#i-cant-run-cargo-test-or-i-cant-build-in-a-cargo-workspace-im-having-linker-issues-like-symbol-not-found-or-undefined-reference-to-_pyexc_systemerror
-requires = ["maturin>=1.15.0"]
+requires = ["maturin>=1.9.4"]
 build-backend = "maturin"
 
 [project]


### PR DESCRIPTION
## What

`build-system.requires` states the oldest `maturin` that can build this crate, and
the comment above it says why that release. An automated dependency update read it
as a version to keep current and raised it to the newest release, which left the
comment explaining a number that is no longer under it, and put the floor above the
version the wheels are actually built with:

    $ git show master:pyproject.toml | grep -n 'requires = \["maturin'
    27:requires = ["maturin>=1.15.0"]
    $ git show master:.github/workflows/ci.yaml | grep -n 'MATURIN_VERSION:'
    36:  MATURIN_VERSION: v1.14.1

The floor goes back to the release the comment describes, and the pin is untouched:

    $ grep -n 'requires = \["maturin' pyproject.toml
    27:requires = ["maturin>=1.9.4"]
    $ grep -n 'MATURIN_VERSION:' .github/workflows/ci.yaml
    36:  MATURIN_VERSION: v1.14.1

`.github/dependabot.yml` now ignores `maturin` in the `uv` ecosystem, so the same
update is not proposed again next month.

## Why

A floor is the oldest release that works, not the newest that exists. Raising it
rejects every older `maturin` for no stated reason, and 1.9.4 is there on purpose:
it is the first release that turns extension-module linking on by itself, so the
crate does not have to enable `pyo3/extension-module`, which dropped the link to
`libpython` and broke `cargo test`.

`maturin` is the build backend rather than a dependency, so nothing resolves that
floor to choose a version. The version the wheels come out of is `MATURIN_VERSION`
in `.github/workflows/ci.yaml`, and this leaves it at `v1.14.1`.

## How to test

`uv sync` builds the extension through the backend, so `just test` and
`just stubtest` exercise it. The wheel and sdist jobs are unaffected: they install
`MATURIN_VERSION` directly rather than resolving the floor.
