### PR TITLE
build(profile): strip symbols from the release extension

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,10 @@ pyo3 = { version = "=0.29.2", features = ["abi3-py310"] }
 pyo3-async-runtimes = { version = "0.29.0", features = ["tokio-runtime"] }
 pyo3-log = "=0.13.4"
 log = "0.4.33"
+
+[profile.release]
+# Measured 2026-09-05 by diffing the CI wheels before and after. On Linux the
+#  extension loses 23% against 1.8% for `"debuginfo"`, on macOS 21%, and on Windows
+#  nothing: its debug information sits in a `.pdb` that no wheel carried.
+#  https://doc.rust-lang.org/cargo/reference/profiles.html#strip
+strip = "symbols"


### PR DESCRIPTION
## What

The release profile carried cargo's default `strip = "none"`, so every published
wheel shipped the extension's symbol table. The published manylinux extension held
860 KB of it and no `.debug_*` at all, which is why this sets `"symbols"` rather
than the softer `"debuginfo"`: there is no debug info here for the latter to take.

Measured on the manylinux x86_64 extension, stripped both ways:

    as published            3670200 bytes
    strip = "debuginfo"     3605912 bytes   (-64288, 1.8%)
    strip = "symbols"       2810000 bytes   (-860200, 23.4%)

Built both ways through this workflow, the wheels come out at:

    platform        binary before   binary after      delta   wheel before   wheel after     delta
    linux x86_64         3670200        2810160    -860040        1208476       1076980    -131496
    macos aarch64        3279920        2580480    -699440        1108404        990855    -117549
    windows x64          2654208        2654208          0         981337        981076       -261

Windows gains nothing and cannot: the binary is byte-identical, because MSVC keeps
debug information in a separate `.pdb` that was never inside the wheel. The 261 bytes
are zip metadata.

The extension still loads. `.dynsym` survives the strip and the entry point stays
exported:

    $ nm -D shazamio_core.abi3.so | grep PyInit_shazamio_core
    00000000000df150 T PyInit_shazamio_core

A wheel built this way went into a clean environment, with the source tree kept out
of `sys.path`, and the suite passed against it:

    16 passed in 0.34s

## Why

A profile key rather than `maturin build --strip`, which is a flag on one command and
would have to be repeated in four workflow steps and both manylinux images. The key
covers every path at once and sits next to the code it applies to.

The cost is that a panic in a released wheel has no symbolised backtrace. Nothing
collects one today, and a reproducible panic is diagnosed on a debug build rather
than from a published artifact.

## How to test

`just test` after `uv sync`. For the artifact itself, run `file` on the extension
inside a Linux wheel this run produces: it reports `stripped`. `file` says nothing
about that for the macOS Mach-O, where the 699440 bytes it lost are the evidence.
