### PR TITLE
fix(algorithm): compute the segment window in a type wide enough to hold it

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,9 @@ signature = await recognizer.recognize_path(
 )
 ```
 
-`SearchParams` wins where both are given.
+`SearchParams` wins where both are given. The duration must be at least 1; zero
+raises `ValueError`. A value at or above the length of the file analyses it whole,
+whatever the value.
 
 ### Errors
 

--- a/shazamio_core/shazamio_core.pyi
+++ b/shazamio_core/shazamio_core.pyi
@@ -68,6 +68,7 @@ class SearchParams:
           - Example: If the audio is **8 seconds** and `segment_duration_seconds = 10`, the entire **8-second file** will be processed.
         - **Audio is always converted to mono and down sampled to 16 kHz** before analysis.
         - This parameter determines the number of samples used for frequency analysis and fingerprint generation.
+        - **Must be at least 1.** Zero raises `ValueError`, at the constructor and on assignment.
     """
 
     segment_duration_seconds: int
@@ -99,6 +100,7 @@ class Recognizer:
               - Example: If the audio is **8 seconds** and `segment_duration_seconds = 10`, the entire **8-second file** will be processed.
             - **Audio is always converted to mono and down sampled to 16 kHz** before analysis.
             - This parameter determines the number of samples used for frequency analysis and fingerprint generation.
+            - **Must be at least 1.** Zero raises `ValueError`, at the constructor and on assignment.
         """
 
     async def recognize_path(

--- a/src/fingerprinting/algorithm.rs
+++ b/src/fingerprinting/algorithm.rs
@@ -8,6 +8,12 @@ use std::error::Error;
 use std::fs;
 use std::path::Path;
 
+// The rate every entry point resamples to before fingerprinting, and the rate the
+//  signature declares.
+pub(crate) const SAMPLE_RATE_HZ: u32 = 16000;
+
+pub(crate) const DEFAULT_SEGMENT_DURATION_SECONDS: u32 = 10;
+
 pub struct SignatureGenerator {
     ring_buffer_of_samples: Vec<i16>,
     reordered_ring_buffer_of_samples: Vec<f32>,
@@ -26,63 +32,48 @@ impl SignatureGenerator {
         resample(samples_from_bytes(bytes)?)
     }
 
+    // A file no longer than the requested segment is fingerprinted whole; a longer one
+    //  is cut from its middle, where recognition odds are best.
+    fn middle_segment(samples: &[i16], segment_duration_seconds: Option<u32>) -> &[i16] {
+        let duration_seconds = segment_duration_seconds.unwrap_or(DEFAULT_SEGMENT_DURATION_SECONDS);
+
+        // The product leaves `u32` at 268436 seconds, and `usize` is 32 bits wide on
+        //  the `i686` wheel, so both are too narrow for a duration callers may pass:
+        //  268436 selected 544 ms of an 8 s file instead of the whole of it.
+        let segment_samples =
+            (duration_seconds as u64 * SAMPLE_RATE_HZ as u64).min(usize::MAX as u64) as usize;
+
+        if samples.len() <= segment_samples {
+            return samples;
+        }
+
+        let middle = samples.len() / 2;
+        let half_segment = segment_samples / 2;
+
+        &samples[middle - half_segment..middle + half_segment]
+    }
+
     pub fn make_signature_from_bytes(
         bytes: Vec<u8>,
         segment_duration_seconds: Option<u32>,
     ) -> Result<DecodedSignature, Box<dyn Error>> {
         let raw_pcm_samples = SignatureGenerator::pcm_samples_from_bytes(bytes)?;
+        let segment =
+            SignatureGenerator::middle_segment(&raw_pcm_samples, segment_duration_seconds);
 
-        // Process the PCM samples as in `make_signature_from_buffer`.
-        let duration_seconds = segment_duration_seconds.unwrap_or(10);
-        let sample_rate = 16000;
-        let segment_samples = (duration_seconds * sample_rate) as usize;
-
-        let raw_pcm_samples_slice: &[i16] = if raw_pcm_samples.len() > segment_samples {
-            let middle = raw_pcm_samples.len() / 2;
-            let half_segment = segment_samples / 2;
-            if middle >= half_segment && middle + half_segment <= raw_pcm_samples.len() {
-                &raw_pcm_samples[middle - half_segment..middle + half_segment]
-            } else {
-                &raw_pcm_samples[..segment_samples]
-            }
-        } else {
-            &raw_pcm_samples[..]
-        };
-
-        // Generate signature from buffer
-        let signature =
-            SignatureGenerator::make_signature_from_buffer(raw_pcm_samples_slice.to_vec());
-
-        // Return the generated signature
-        Ok(signature)
+        Ok(SignatureGenerator::make_signature_from_buffer(
+            segment.to_vec(),
+        ))
     }
 
     pub fn make_signature_from_file(
         file_path: &Path,
         segment_duration_seconds: Option<u32>,
     ) -> Result<DecodedSignature, Box<dyn Error>> {
-        // Decode the .WAV, .MP3, .OGG or .FLAC file
-        let raw_pcm_samples = SignatureGenerator::pcm_samples_from_bytes(fs::read(file_path)?)?;
-
-        // Downsample the raw PCM samples to 16 KHz, and skip to the middle of the file
-        //  to increase recognition odds. Take N (10 by default) seconds of sample.
-        let duration_seconds = segment_duration_seconds.unwrap_or(10);
-        let sample_rate = 16000;
-        let segment_samples = (duration_seconds * sample_rate) as usize;
-
-        let slice_len = raw_pcm_samples.len().min(segment_samples);
-        let mut raw_pcm_samples_slice: &[i16] = &raw_pcm_samples[..slice_len];
-
-        if raw_pcm_samples.len() > segment_samples {
-            let middle = raw_pcm_samples.len() / 2;
-            raw_pcm_samples_slice =
-                &raw_pcm_samples[middle - segment_samples / 2..middle + segment_samples / 2];
-        }
-
-        let signature =
-            SignatureGenerator::make_signature_from_buffer(raw_pcm_samples_slice.to_vec());
-
-        Ok(signature)
+        SignatureGenerator::make_signature_from_bytes(
+            fs::read(file_path)?,
+            segment_duration_seconds,
+        )
     }
 
     pub fn make_signature_from_buffer(s16_mono_16khz_buffer: Vec<i16>) -> DecodedSignature {
@@ -103,7 +94,7 @@ impl SignatureGenerator {
             num_spread_ffts_done: 0,
 
             signature: DecodedSignature {
-                sample_rate_hz: 16000,
+                sample_rate_hz: SAMPLE_RATE_HZ,
                 number_samples: s16_mono_16khz_buffer.len() as u32,
                 frequency_band_to_sound_peaks: HashMap::new(),
             },
@@ -518,6 +509,30 @@ mod tests {
             from_bytes.encode_to_uri().unwrap(),
             from_file.encode_to_uri().unwrap(),
         );
+    }
+
+    #[test]
+    fn a_duration_at_or_above_the_file_length_selects_the_whole_file() {
+        // 8 s at 16 kHz, which is `probe.flac` resampled and not cut.
+        const WHOLE_FILE_SAMPLES: u32 = 8 * 16000;
+
+        // 268436 is where the product left `u32`: it selected 544 ms of this file and
+        //  reported success, and 268435456 selected nothing at all.
+        for duration in [10, 268_436, 268_435_456, u32::MAX] {
+            let from_file = SignatureGenerator::make_signature_from_file(
+                &probe_path("probe.flac"),
+                Some(duration),
+            )
+            .unwrap();
+            let from_bytes = SignatureGenerator::make_signature_from_bytes(
+                std::fs::read(probe_path("probe.flac")).unwrap(),
+                Some(duration),
+            )
+            .unwrap();
+
+            assert_eq!(from_file.number_samples, WHOLE_FILE_SAMPLES, "{duration}");
+            assert_eq!(from_bytes.number_samples, WHOLE_FILE_SAMPLES, "{duration}");
+        }
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,12 +5,12 @@ mod response;
 mod utils;
 
 use crate::errors::SignatureError;
-use crate::params::SearchParams;
+use crate::params::{validated_segment_duration_seconds, SearchParams};
 use crate::response::{Geolocation, Signature, SignatureSong};
 use crate::utils::convert_signature_to_py;
 use crate::utils::get_python_future;
 use crate::utils::unwrap_decoded_signature;
-use fingerprinting::algorithm::SignatureGenerator;
+use fingerprinting::algorithm::{SignatureGenerator, DEFAULT_SEGMENT_DURATION_SECONDS};
 use log::{debug, error, info};
 use pyo3::prelude::*;
 use pyo3::types::PyModule;
@@ -36,7 +36,6 @@ fn shazamio_core(m: &Bound<'_, PyModule>) -> PyResult<()> {
 #[derive(Clone)]
 #[pyclass(from_py_object, module = "shazamio_core")]
 struct Recognizer {
-    #[pyo3(get, set)]
     segment_duration_seconds: u32,
 }
 
@@ -44,15 +43,29 @@ struct Recognizer {
 impl Recognizer {
     #[new]
     #[pyo3(signature = (segment_duration_seconds=None))]
-    pub fn new(segment_duration_seconds: Option<u32>) -> Self {
-        let duration = segment_duration_seconds.unwrap_or(10);
+    pub fn new(segment_duration_seconds: Option<u32>) -> PyResult<Self> {
+        let duration = validated_segment_duration_seconds(
+            segment_duration_seconds.unwrap_or(DEFAULT_SEGMENT_DURATION_SECONDS),
+        )?;
         info!(
             "Recognizer created with segment_duration_seconds = {}",
             duration
         );
-        Recognizer {
+        Ok(Recognizer {
             segment_duration_seconds: duration,
-        }
+        })
+    }
+
+    #[getter]
+    fn get_segment_duration_seconds(&self) -> u32 {
+        self.segment_duration_seconds
+    }
+
+    #[setter]
+    fn set_segment_duration_seconds(&mut self, value: u32) -> PyResult<()> {
+        self.segment_duration_seconds = validated_segment_duration_seconds(value)?;
+
+        Ok(())
     }
 
     #[pyo3(signature = (value, options=None))]
@@ -68,13 +81,16 @@ impl Recognizer {
             options,
         );
 
-        let search_options = options.unwrap_or_else(|| {
-            debug!(
-                "Options not provided, using default segment duration {}",
-                self.segment_duration_seconds,
-            );
-            SearchParams::new(Option::from(self.segment_duration_seconds))
-        });
+        let search_options = match options {
+            Some(options) => options,
+            None => {
+                debug!(
+                    "Options not provided, using default segment duration {}",
+                    self.segment_duration_seconds,
+                );
+                SearchParams::new(Some(self.segment_duration_seconds))?
+            }
+        };
 
         let future = async move {
             debug!("Starting async recognition from bytes");
@@ -111,13 +127,16 @@ impl Recognizer {
             options,
         );
 
-        let search_options = options.unwrap_or_else(|| {
-            debug!(
-                "Options not provided, using default segment duration {}",
-                self.segment_duration_seconds,
-            );
-            SearchParams::new(Option::from(self.segment_duration_seconds))
-        });
+        let search_options = match options {
+            Some(options) => options,
+            None => {
+                debug!(
+                    "Options not provided, using default segment duration {}",
+                    self.segment_duration_seconds,
+                );
+                SearchParams::new(Some(self.segment_duration_seconds))?
+            }
+        };
 
         let future = async move {
             debug!("Starting async recognition from file: {}", value.display());
@@ -149,8 +168,11 @@ mod tests {
     // The same default `SearchParams` carries, and `shazamio_core.pyi` documents.
     #[test]
     fn a_recognizer_defaults_to_a_ten_second_segment() {
-        assert_eq!(Recognizer::new(None).segment_duration_seconds, 10);
-        assert_eq!(Recognizer::new(Some(4)).segment_duration_seconds, 4);
+        assert_eq!(Recognizer::new(None).unwrap().segment_duration_seconds, 10);
+        assert_eq!(
+            Recognizer::new(Some(4)).unwrap().segment_duration_seconds,
+            4
+        );
     }
 
     // `stubtest` and `tests/test_init.py` compare the same list against the `.pyi`

--- a/src/params.rs
+++ b/src/params.rs
@@ -1,20 +1,48 @@
-use pyo3::{pyclass, pymethods};
+use crate::fingerprinting::algorithm::DEFAULT_SEGMENT_DURATION_SECONDS;
+use pyo3::exceptions::PyValueError;
+use pyo3::{pyclass, pymethods, PyResult};
 use serde::{Deserialize, Serialize};
+
+// A zero-second segment fingerprints nothing: it produced an empty signature and
+//  reported success. There is no upper bound to enforce, because a duration at or
+//  above the file length uses the whole file.
+pub(crate) fn validated_segment_duration_seconds(value: u32) -> PyResult<u32> {
+    if value == 0 {
+        return Err(PyValueError::new_err(
+            "segment_duration_seconds must be at least 1",
+        ));
+    }
+
+    Ok(value)
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[pyclass(from_py_object, module = "shazamio_core")]
 pub(crate) struct SearchParams {
-    #[pyo3(get, set)]
     pub(crate) segment_duration_seconds: u32,
 }
 #[pymethods]
 impl SearchParams {
     #[new]
     #[pyo3(signature = (segment_duration_seconds=None))]
-    pub fn new(segment_duration_seconds: Option<u32>) -> Self {
-        SearchParams {
-            segment_duration_seconds: segment_duration_seconds.unwrap_or(10),
-        }
+    pub fn new(segment_duration_seconds: Option<u32>) -> PyResult<Self> {
+        Ok(SearchParams {
+            segment_duration_seconds: validated_segment_duration_seconds(
+                segment_duration_seconds.unwrap_or(DEFAULT_SEGMENT_DURATION_SECONDS),
+            )?,
+        })
+    }
+
+    #[getter]
+    fn get_segment_duration_seconds(&self) -> u32 {
+        self.segment_duration_seconds
+    }
+
+    #[setter]
+    fn set_segment_duration_seconds(&mut self, value: u32) -> PyResult<()> {
+        self.segment_duration_seconds = validated_segment_duration_seconds(value)?;
+
+        Ok(())
     }
 }
 
@@ -24,7 +52,22 @@ mod tests {
 
     #[test]
     fn the_segment_duration_defaults_to_ten_seconds() {
-        assert_eq!(SearchParams::new(None).segment_duration_seconds, 10);
-        assert_eq!(SearchParams::new(Some(4)).segment_duration_seconds, 4);
+        assert_eq!(
+            SearchParams::new(None).unwrap().segment_duration_seconds,
+            10
+        );
+        assert_eq!(
+            SearchParams::new(Some(4)).unwrap().segment_duration_seconds,
+            4
+        );
+    }
+
+    #[test]
+    fn a_zero_segment_duration_is_refused() {
+        let mut parameters = SearchParams::new(Some(4)).unwrap();
+
+        assert!(SearchParams::new(Some(0)).is_err());
+        assert!(parameters.set_segment_duration_seconds(0).is_err());
+        assert_eq!(parameters.segment_duration_seconds, 4);
     }
 }

--- a/tests/test_recognizer.py
+++ b/tests/test_recognizer.py
@@ -31,7 +31,7 @@ from typing import Final
 
 import pytest
 
-from shazamio_core import Recognizer
+from shazamio_core import Recognizer, SearchParams
 
 DATA_DIRECTORY: Final[Path] = Path(__file__).parent / "data"
 
@@ -102,6 +102,23 @@ async def test_a_wider_opus_stream_decodes(
     signature = await recognizer.recognize_path(DATA_DIRECTORY / file_name)
 
     assert signature.signature.samples == expected_duration_ms
+
+
+@pytest.mark.parametrize("segment_duration_seconds", [268_436, 4_294_967_295])
+async def test_a_segment_longer_than_the_file_analyses_it_whole(
+    segment_duration_seconds: int,
+    *,
+    recognizer: Recognizer,
+) -> None:
+    # The window was computed in a type too narrow to hold it, so 268436 seconds
+    #  selected 544 ms of this 8-second file and the largest accepted value nothing
+    #  at all, both reporting success.
+    signature = await recognizer.recognize_path(
+        _probe(GOLDEN_AUDIO_FORMAT),
+        SearchParams(segment_duration_seconds),
+    )
+
+    assert signature.signature.samples == EXPECTED_DURATION_MS
 
 
 async def test_recognize_path_accepts_a_string_too(*, recognizer: Recognizer) -> None:

--- a/tests/test_recognizer.py
+++ b/tests/test_recognizer.py
@@ -121,6 +121,28 @@ async def test_a_segment_longer_than_the_file_analyses_it_whole(
     assert signature.signature.samples == EXPECTED_DURATION_MS
 
 
+def test_a_zero_segment_duration_is_refused() -> None:
+    with pytest.raises(ValueError):
+        Recognizer(0)
+
+    with pytest.raises(ValueError):
+        SearchParams(0)
+
+
+def test_a_zero_segment_duration_is_refused_on_assignment_too() -> None:
+    recognizer = Recognizer()
+    search_parameters = SearchParams()
+
+    with pytest.raises(ValueError):
+        recognizer.segment_duration_seconds = 0
+
+    with pytest.raises(ValueError):
+        search_parameters.segment_duration_seconds = 0
+
+    assert recognizer.segment_duration_seconds == 10
+    assert search_parameters.segment_duration_seconds == 10
+
+
 async def test_recognize_path_accepts_a_string_too(*, recognizer: Recognizer) -> None:
     # `recognize_path` extracts a Rust `PathBuf` through `os.fspath`, so a `str` and
     #  a `Path` both work. It used to extract a `String` and reject a `Path` with


### PR DESCRIPTION
## What

`segment_duration_seconds` picks how much of a long file is fingerprinted, and the
window was computed as `segment_duration_seconds * 16000` in a type too narrow to
hold the result. The product leaves `u32` at 268436 seconds, and `usize` is 32 bits
wide on the `i686` wheel we publish, so a value a caller may legitimately pass wrapped
and selected the wrong slice while still reporting success. Zero was accepted too, and
fingerprinted nothing.

Measured through a built extension on `tests/data/probe.flac`, which is 8 seconds long.
`signature.samples` is a duration in milliseconds, not a count.

Before:

    duration 10           8000 ms
    duration 268435       8000 ms
    duration 268436        544 ms
    duration 268435456       0 ms
    duration 4294967295   8000 ms
    duration 0               0 ms

After:

    duration 10           8000 ms
    duration 268435       8000 ms
    duration 268436      8000 ms
    duration 268435456   8000 ms
    duration 4294967295  8000 ms
    duration 0           ValueError: segment_duration_seconds must be at least 1

Three changes get there:

- The window is computed in `u64` and saturated into `usize`, so no accepted duration
  can wrap. A duration at or above the length of the file analyses it whole, whatever
  the value.
- The accepted range is `1..=u32::MAX`, validated in one place for both classes:
  `Recognizer.__new__`, `SearchParams.__new__` and both setters. There is deliberately
  no upper bound, because "longer than the file" already has a defined meaning.
- The two entry points share one path again. `make_signature_from_file` reads the bytes
  and calls `make_signature_from_bytes`, and the middle segment slicing lives in a
  single helper instead of being written out twice, once per entry point, with the
  `16000` literal repeated at three sites.

## What this does not cover

The sample rate stays a compile time constant. Callers cannot ask for a different one,
and nothing here changes what the fingerprint contains: the golden URI is unchanged,
which is the evidence that folding the two entry points together moved nothing.

## How to test

    just all

Rust covers 10, 268436, 268435456 and `u32::MAX` on both entry points. Python covers the
two large durations end to end and the refusal of zero at both constructors and both
setters.
