### PR TITLE
perf(decode): stream the decode and resample instead of holding the whole recording

### DIFF
--- a/src/fingerprinting/algorithm.rs
+++ b/src/fingerprinting/algorithm.rs
@@ -1,11 +1,10 @@
-use crate::fingerprinting::decode::samples_from_bytes;
+use crate::fingerprinting::decode::MonoDecoder;
 use crate::fingerprinting::hanning::HANNING_WINDOW_2048_MULTIPLIERS;
-use crate::fingerprinting::resample::resample;
+use crate::fingerprinting::resample::Resampling;
 use crate::fingerprinting::signature_format::{DecodedSignature, FrequencyBand, FrequencyPeak};
 use chfft::RFft1D;
 use std::collections::HashMap;
 use std::error::Error;
-use std::fs;
 use std::path::Path;
 
 // The rate every entry point resamples to before fingerprinting, and the rate the
@@ -28,8 +27,17 @@ pub struct SignatureGenerator {
 }
 
 impl SignatureGenerator {
-    fn pcm_samples_from_bytes(bytes: Vec<u8>) -> Result<Vec<i16>, Box<dyn Error>> {
-        resample(samples_from_bytes(bytes)?)
+    // Decoded, mixed down and resampled a packet at a time, so nothing longer than one
+    //  packet of the source is ever held beside the 16 kHz result.
+    fn pcm_samples(mut decoder: MonoDecoder) -> Result<Vec<i16>, Box<dyn Error>> {
+        let mut resampling = Resampling::new(decoder.spec().rate)?;
+        let mut mono_frames = Vec::new();
+
+        while decoder.next_chunk(&mut mono_frames)? {
+            resampling.push(&mono_frames)?;
+        }
+
+        resampling.finish()
     }
 
     // A file no longer than the requested segment is fingerprinted whole; a longer one
@@ -57,23 +65,35 @@ impl SignatureGenerator {
         bytes: Vec<u8>,
         segment_duration_seconds: Option<u32>,
     ) -> Result<DecodedSignature, Box<dyn Error>> {
-        let raw_pcm_samples = SignatureGenerator::pcm_samples_from_bytes(bytes)?;
-        let segment =
-            SignatureGenerator::middle_segment(&raw_pcm_samples, segment_duration_seconds);
-
-        Ok(SignatureGenerator::make_signature_from_buffer(
-            segment.to_vec(),
-        ))
+        SignatureGenerator::make_signature(
+            MonoDecoder::from_bytes(bytes)?,
+            segment_duration_seconds,
+        )
     }
 
     pub fn make_signature_from_file(
         file_path: &Path,
         segment_duration_seconds: Option<u32>,
     ) -> Result<DecodedSignature, Box<dyn Error>> {
-        SignatureGenerator::make_signature_from_bytes(
-            fs::read(file_path)?,
+        // Read through as it decodes rather than with `fs::read`, which held the whole
+        //  file: 30 minutes of stereo FLAC is 230 MB of bytes before a sample is decoded.
+        SignatureGenerator::make_signature(
+            MonoDecoder::from_file(file_path)?,
             segment_duration_seconds,
         )
+    }
+
+    fn make_signature(
+        decoder: MonoDecoder,
+        segment_duration_seconds: Option<u32>,
+    ) -> Result<DecodedSignature, Box<dyn Error>> {
+        let raw_pcm_samples = SignatureGenerator::pcm_samples(decoder)?;
+        let segment =
+            SignatureGenerator::middle_segment(&raw_pcm_samples, segment_duration_seconds);
+
+        Ok(SignatureGenerator::make_signature_from_buffer(
+            segment.to_vec(),
+        ))
     }
 
     pub fn make_signature_from_buffer(s16_mono_16khz_buffer: Vec<i16>) -> DecodedSignature {
@@ -320,19 +340,34 @@ mod tests {
     struct ProbeShape {
         frames: usize,
         channels: usize,
+        rate: u32,
     }
 
-    // The same read-and-decode the path entry point does, so a test here cannot prove
-    //  something that entry point does not.
-    fn decode_probe(name: &str) -> Result<ProbeShape, Box<dyn Error>> {
-        let bytes = std::fs::read(probe_path(name))?;
-        let decoded_audio = samples_from_bytes(bytes)?;
-        let channels = decoded_audio.spec.channels.count();
+    // The same decode the entry points drive, so a test here cannot prove something they
+    //  do not do. Mixing down keeps one value per frame, so the count is the frame count.
+    fn decode(mut decoder: MonoDecoder) -> Result<ProbeShape, SymphoniaError> {
+        let mut mono_frames = Vec::new();
+        let mut frames = 0;
+
+        while decoder.next_chunk(&mut mono_frames)? {
+            frames += mono_frames.len();
+        }
 
         Ok(ProbeShape {
-            frames: decoded_audio.samples.len() / channels,
-            channels,
+            frames,
+            channels: decoder.spec().channels.count(),
+            rate: decoder.spec().rate,
         })
+    }
+
+    // The same read-and-decode the path entry point does.
+    fn decode_probe(name: &str) -> Result<ProbeShape, SymphoniaError> {
+        decode(MonoDecoder::from_file(&probe_path(name))?)
+    }
+
+    // What the bytes entry point does instead, for a stream no file holds.
+    fn decode_bytes(bytes: Vec<u8>) -> Result<ProbeShape, SymphoniaError> {
+        decode(MonoDecoder::from_bytes(bytes)?)
     }
 
     #[test]
@@ -352,12 +387,10 @@ mod tests {
         //  count is against that rate rather than against the source's 44.1 kHz.
         const OPUS_RATE: usize = 48_000;
 
-        let bytes = std::fs::read(Path::new(DATA_DIRECTORY).join("probe.opus")).unwrap();
-        let decoded_audio = samples_from_bytes(bytes).unwrap();
-        let frames = decoded_audio.samples.len() / decoded_audio.spec.channels.count();
+        let probe = decode_probe("probe.opus").unwrap();
 
-        assert_eq!(decoded_audio.spec.rate as usize, OPUS_RATE);
-        assert_eq!(frames, 8 * OPUS_RATE);
+        assert_eq!(probe.rate as usize, OPUS_RATE);
+        assert_eq!(probe.frames, 8 * OPUS_RATE);
     }
 
     #[test]
@@ -368,10 +401,9 @@ mod tests {
         let mut chained = std::fs::read(probe_path("probe.opus")).unwrap();
         chained.extend_from_slice(&chained.clone());
 
-        let decoded_audio = samples_from_bytes(chained).unwrap();
-        let frames = decoded_audio.samples.len() / decoded_audio.spec.channels.count();
+        let probe = decode_bytes(chained).unwrap();
 
-        assert_eq!(frames, 2 * 8 * 48_000);
+        assert_eq!(probe.frames, 2 * 8 * 48_000);
     }
 
     #[test]
@@ -405,7 +437,7 @@ mod tests {
         let mut chained = std::fs::read(probe_path("probe.opus")).unwrap();
         chained.extend_from_slice(&std::fs::read(probe_path("surround.opus")).unwrap());
 
-        let Err(error) = samples_from_bytes(chained) else {
+        let Err(error) = decode_bytes(chained) else {
             panic!("a stream that changes format decoded");
         };
 

--- a/src/fingerprinting/decode.rs
+++ b/src/fingerprinting/decode.rs
@@ -1,21 +1,17 @@
+use std::fs::File;
 use std::io::{Cursor, ErrorKind};
+use std::path::Path;
 use std::sync::OnceLock;
 
 use symphonia::core::audio::{SampleBuffer, SignalSpec};
 use symphonia::core::codecs::{CodecRegistry, Decoder, DecoderOptions, CODEC_TYPE_NULL};
 use symphonia::core::errors::Error;
 use symphonia::core::formats::{FormatOptions, FormatReader};
-use symphonia::core::io::MediaSourceStream;
+use symphonia::core::io::{MediaSource, MediaSourceStream};
 use symphonia::core::meta::MetadataOptions;
 use symphonia::core::probe::Hint;
 
 use crate::fingerprinting::opus_decoder::OpusDecoder;
-
-/// Samples interleaved by channel, and the spec they were decoded under.
-pub struct DecodedAudio {
-    pub spec: SignalSpec,
-    pub samples: Vec<f32>,
-}
 
 /// Every codec `symphonia` enables, plus the Opus decoder it does not ship.
 fn codec_registry() -> &'static CodecRegistry {
@@ -51,102 +47,171 @@ fn decoder_for(format: &dyn FormatReader) -> Result<TrackDecoder, Error> {
     })
 }
 
-pub fn samples_from_bytes(bytes: Vec<u8>) -> Result<DecodedAudio, Error> {
-    let media_source = MediaSourceStream::new(Box::new(Cursor::new(bytes)), Default::default());
+/// Reads the packets of one track, decoded and mixed down to mono.
+struct PacketDecoder {
+    format: Box<dyn FormatReader>,
+    track_decoder: TrackDecoder,
+    sample_buffer: Option<SampleBuffer<f32>>,
+}
 
-    // A lossy encoder pads the stream it writes, and the padding is silence the
-    //  container describes rather than audio. Left off, `probe.opus` decoded to
-    //  8013 ms of an 8000 ms source and `probe.mp3` to 8045 ms of the same.
-    //  https://docs.rs/symphonia-core/0.5.5/symphonia_core/formats/struct.FormatOptions.html#structfield.enable_gapless
-    let format_options = FormatOptions {
-        enable_gapless: true,
-        ..Default::default()
-    };
+impl PacketDecoder {
+    fn new(source: Box<dyn MediaSource>) -> Result<Self, Error> {
+        let media_source = MediaSourceStream::new(source, Default::default());
 
-    let probe_result = symphonia::default::get_probe().format(
-        &Hint::new(),
-        media_source,
-        &format_options,
-        &MetadataOptions::default(),
-    )?;
+        // A lossy encoder pads the stream it writes, and the padding is silence the
+        //  container describes rather than audio. Left off, `probe.opus` decoded to
+        //  8013 ms of an 8000 ms source and `probe.mp3` to 8045 ms of the same.
+        //  https://docs.rs/symphonia-core/0.5.5/symphonia_core/formats/struct.FormatOptions.html#structfield.enable_gapless
+        let format_options = FormatOptions {
+            enable_gapless: true,
+            ..Default::default()
+        };
 
-    let mut format = probe_result.format;
-    let mut track_decoder = decoder_for(format.as_ref())?;
+        let probe_result = symphonia::default::get_probe().format(
+            &Hint::new(),
+            media_source,
+            &format_options,
+            &MetadataOptions::default(),
+        )?;
 
-    // The spec comes from the packets rather than from the container, because the
-    //  decoder is the authority on what it produced. Nothing is assumed before the
-    //  first one arrives, so a stream that decodes to nothing is an error below.
-    let mut spec: Option<SignalSpec> = None;
-    let mut sample_buffer: Option<SampleBuffer<f32>> = None;
-    let mut aggregate_samples: Vec<f32> = Vec::new();
+        let format = probe_result.format;
+        let track_decoder = decoder_for(format.as_ref())?;
 
-    loop {
-        let packet = match format.next_packet() {
-            Ok(packet) => packet,
+        Ok(PacketDecoder {
+            format,
+            track_decoder,
+            sample_buffer: None,
+        })
+    }
 
-            // `next_packet` reports the end of the stream as an `UnexpectedEof` read
-            //  error rather than as `None`, and every other error is real.
-            //  https://docs.rs/symphonia-core/0.5.5/symphonia_core/formats/trait.FormatReader.html#tymethod.next_packet
-            Err(Error::IoError(er)) if er.kind() == ErrorKind::UnexpectedEof => break,
+    /// Fills `mono_frames` with the next packet and reports the spec it decoded under,
+    /// or `None` once the stream ends.
+    fn next(&mut self, mono_frames: &mut Vec<f32>) -> Result<Option<SignalSpec>, Error> {
+        mono_frames.clear();
 
-            // A chained Ogg file opens a second logical stream, and the reader asks
-            //  for a new decoder rather than for the read to stop. Read as the end, a
-            //  four-second chained file decoded to 2013 ms and reported success.
-            //  https://www.rfc-editor.org/rfc/rfc7845#section-2
-            Err(Error::ResetRequired) => {
-                track_decoder = decoder_for(format.as_ref())?;
+        loop {
+            let packet = match self.format.next_packet() {
+                Ok(packet) => packet,
+
+                // `next_packet` reports the end of the stream as an `UnexpectedEof` read
+                //  error rather than as `None`, and every other error is real.
+                //  https://docs.rs/symphonia-core/0.5.5/symphonia_core/formats/trait.FormatReader.html#tymethod.next_packet
+                Err(Error::IoError(er)) if er.kind() == ErrorKind::UnexpectedEof => {
+                    return Ok(None)
+                }
+
+                // A chained Ogg file opens a second logical stream, and the reader asks
+                //  for a new decoder rather than for the read to stop. Read as the end, a
+                //  four-second chained file decoded to 2013 ms and reported success.
+                //  https://www.rfc-editor.org/rfc/rfc7845#section-2
+                Err(Error::ResetRequired) => {
+                    self.track_decoder = decoder_for(self.format.as_ref())?;
+                    continue;
+                }
+
+                Err(er) => return Err(er),
+            };
+
+            // If the packet does not belong to the selected track, skip it.
+            if packet.track_id() != self.track_decoder.track_id {
                 continue;
             }
 
-            Err(er) => return Err(er),
+            let audio_buffer = self.track_decoder.decoder.decode(&packet)?;
+            let spec = *audio_buffer.spec();
+            let channel_count = spec.channels.count();
+
+            // `SampleBuffer::capacity` counts samples and `AudioBufferRef::capacity`
+            //  frames, so comparing them raw let a stereo packet reuse a buffer half the
+            //  size it needed, and `copy_interleaved_ref` panicked on its own assertion.
+            let required_samples = audio_buffer.capacity() * channel_count;
+
+            if self
+                .sample_buffer
+                .as_ref()
+                .is_none_or(|buffer| buffer.capacity() < required_samples)
+            {
+                self.sample_buffer = Some(SampleBuffer::new(audio_buffer.capacity() as u64, spec));
+            }
+
+            if let Some(buffer) = self.sample_buffer.as_mut() {
+                buffer.copy_interleaved_ref(audio_buffer);
+
+                // Mixing down here rather than after the whole file is what keeps the
+                //  interleaved samples of a long recording from being held at all.
+                mono_frames.resize(buffer.samples().len() / channel_count, 0f32);
+
+                for (index, sample) in buffer.samples().iter().enumerate() {
+                    mono_frames[index / channel_count] += sample / channel_count as f32;
+                }
+            }
+
+            return Ok(Some(spec));
+        }
+    }
+}
+
+/// Decodes a stream one packet at a time, mixed down to mono at the rate it declares.
+pub struct MonoDecoder {
+    packets: PacketDecoder,
+    spec: SignalSpec,
+    first_chunk: Option<Vec<f32>>,
+}
+
+impl MonoDecoder {
+    /// Reads a stream already in memory, as the bytes entry point hands it over.
+    pub fn from_bytes(bytes: Vec<u8>) -> Result<Self, Error> {
+        MonoDecoder::new(Box::new(Cursor::new(bytes)))
+    }
+
+    /// Reads a file from disk, so a long recording is never held as bytes either.
+    pub fn from_file(file_path: &Path) -> Result<Self, Error> {
+        MonoDecoder::new(Box::new(File::open(file_path)?))
+    }
+
+    fn new(source: Box<dyn MediaSource>) -> Result<Self, Error> {
+        let mut packets = PacketDecoder::new(source)?;
+        let mut first_chunk = Vec::new();
+
+        // The spec comes from the packets rather than from the container, because the
+        //  decoder is the authority on what it produced. Nothing is assumed before the
+        //  first one arrives, so a stream that decodes to nothing is an error here.
+        let Some(spec) = packets.next(&mut first_chunk)? else {
+            return Err(Error::DecodeError("the stream carries no decodable audio"));
         };
 
-        // If the packet does not belong to the selected track, skip it.
-        if packet.track_id() != track_decoder.track_id {
-            continue;
+        Ok(MonoDecoder {
+            packets,
+            spec,
+            first_chunk: Some(first_chunk),
+        })
+    }
+
+    /// The spec every packet of the stream decodes under.
+    pub fn spec(&self) -> SignalSpec {
+        self.spec
+    }
+
+    /// Takes the next packet of the stream, and reports whether one arrived.
+    pub fn next_chunk(&mut self, mono_frames: &mut Vec<f32>) -> Result<bool, Error> {
+        if let Some(first_chunk) = self.first_chunk.take() {
+            *mono_frames = first_chunk;
+            return Ok(true);
         }
 
-        let audio_buffer = track_decoder.decoder.decode(&packet)?;
-        let packet_spec = *audio_buffer.spec();
+        let Some(spec) = self.packets.next(mono_frames)? else {
+            return Ok(false);
+        };
 
         // A chained stream may open its next link at another rate or channel count, and
-        //  samples of two shapes cannot share one buffer. Appended regardless, a 2 s
-        //  mono link followed by a 2 s stereo one came out as 3000 ms of a 4000 ms file.
-        if spec.is_some_and(|established| established != packet_spec) {
+        //  frames of two shapes cannot share one stream. Accepted regardless, a 2 s mono
+        //  link followed by a 2 s stereo one came out as 3000 ms of a 4000 ms file.
+        if spec != self.spec {
             return Err(Error::Unsupported(
                 "the stream changes format part-way through",
             ));
         }
 
-        // `SampleBuffer::capacity` counts samples and `AudioBufferRef::capacity`
-        //  frames, so comparing them raw let a stereo packet reuse a buffer half the
-        //  size it needed, and `copy_interleaved_ref` panicked on its own assertion.
-        let required_samples = audio_buffer.capacity() * packet_spec.channels.count();
-
-        if sample_buffer
-            .as_ref()
-            .is_none_or(|buffer| buffer.capacity() < required_samples)
-        {
-            sample_buffer = Some(SampleBuffer::new(
-                audio_buffer.capacity() as u64,
-                packet_spec,
-            ));
-        }
-
-        if let Some(buffer) = sample_buffer.as_mut() {
-            buffer.copy_interleaved_ref(audio_buffer);
-            aggregate_samples.extend_from_slice(buffer.samples());
-        }
-
-        spec = Some(packet_spec);
+        Ok(true)
     }
-
-    let Some(spec) = spec else {
-        return Err(Error::DecodeError("the stream carries no decodable audio"));
-    };
-
-    Ok(DecodedAudio {
-        spec,
-        samples: aggregate_samples,
-    })
 }

--- a/src/fingerprinting/resample.rs
+++ b/src/fingerprinting/resample.rs
@@ -1,48 +1,143 @@
-use crate::fingerprinting::decode::DecodedAudio;
+use crate::fingerprinting::algorithm::SAMPLE_RATE_HZ;
 use rubato::audioadapter_buffers::direct::InterleavedSlice;
-use rubato::{Async, FixedAsync, Resampler, SincInterpolationParameters};
+use rubato::{Async, FixedAsync, Indexing, Resampler, SincInterpolationParameters};
 use std::error::Error;
-
-/// The sample rate the fingerprinting algorithm is defined against.
-const TARGET_RATE: u32 = 16_000;
 
 // The ratio is fixed for a whole clip, so the resampler is never asked to adjust it.
 const MAX_RATIO_RELATIVE: f64 = 1.0;
 
-// Input frames per internal call. `process_all` drives the loop, so this only sizes the
-//  resampler's own buffers.
+// Input frames the resampler takes per call.
 const CHUNK_FRAMES: usize = 1024;
 
-pub fn resample(decoded_audio: DecodedAudio) -> Result<Vec<i16>, Box<dyn Error>> {
-    let channel_count = decoded_audio.spec.channels.count();
-    let frame_count = decoded_audio.samples.len() / channel_count;
+// The stream is mixed down to mono before it is resampled.
+const CHANNEL_COUNT: usize = 1;
 
-    let mut mono_samples = vec![0f32; frame_count];
-    for (index, sample) in decoded_audio.samples.iter().enumerate() {
-        mono_samples[index / channel_count] += sample / channel_count as f32;
+/// Resamples a mono stream to 16 kHz as it arrives, holding only the 16 kHz output.
+///
+/// This is `rubato`'s own `process_all_into_buffer` unrolled over a stream: the chunking,
+/// the delay trim and the final flush are the steps it takes, in its order, so the output
+/// is the one a single whole-clip call produces.
+/// https://github.com/HEnquist/rubato/blob/6b72d0f9d8843c6623c818751730764aefcd0525/src/lib.rs#L323
+pub struct Resampling {
+    resampler: Async<f32>,
+    staged_frames: Vec<f32>,
+    chunk_output: Vec<f32>,
+    output: Vec<i16>,
+    input_frame_count: usize,
+    frames_to_trim: usize,
+}
+
+impl Resampling {
+    pub fn new(source_rate: u32) -> Result<Self, Box<dyn Error>> {
+        // The defaults keep the filter this used to build by hand and differ in two fields:
+        //  the cutoff follows `sinc_len` and the window instead of being pinned at 0.95, and
+        //  `oversampling_factor` is 128 rather than 160. Neither old number was explained.
+        let resampler = Async::<f32>::new_sinc(
+            f64::from(SAMPLE_RATE_HZ) / f64::from(source_rate),
+            MAX_RATIO_RELATIVE,
+            &SincInterpolationParameters::default(),
+            CHUNK_FRAMES,
+            CHANNEL_COUNT,
+            FixedAsync::Input,
+        )?;
+
+        let chunk_output = vec![0f32; resampler.output_frames_max()];
+        let frames_to_trim = resampler.output_delay();
+
+        Ok(Resampling {
+            resampler,
+            staged_frames: Vec::new(),
+            chunk_output,
+            output: Vec::new(),
+            input_frame_count: 0,
+            frames_to_trim,
+        })
     }
 
-    // The defaults keep the filter this used to build by hand and differ in two fields:
-    //  the cutoff follows `sinc_len` and the window instead of being pinned at 0.95, and
-    //  `oversampling_factor` is 128 rather than 160. Neither old number was explained.
-    let mut resampler = Async::<f32>::new_sinc(
-        f64::from(TARGET_RATE) / f64::from(decoded_audio.spec.rate),
-        MAX_RATIO_RELATIVE,
-        &SincInterpolationParameters::default(),
-        CHUNK_FRAMES,
-        1,
-        FixedAsync::Input,
-    )?;
+    /// Takes the next frames of the stream, resampling every whole chunk they complete.
+    pub fn push(&mut self, mono_frames: &[f32]) -> Result<(), Box<dyn Error>> {
+        self.staged_frames.extend_from_slice(mono_frames);
+        self.input_frame_count += mono_frames.len();
 
-    // `process_all` trims the sinc filter's startup delay and the trailing padding, which a
-    //  single `process` call leaves in: the clip would come out shifted by `output_delay`
-    //  frames of silence and cut short at the end.
-    let input = InterleavedSlice::new(&mono_samples, 1, frame_count)?;
-    let resampled = resampler.process_all(&input, frame_count, None)?;
+        // Strictly greater, because `rubato` takes a full chunk only while more than one
+        //  is left and hands whatever remains to the partial call `finish` makes.
+        while self.staged_frames.len() > CHUNK_FRAMES {
+            let consumed_frames = self.resample_chunk(None)?;
 
-    Ok(resampled
-        .take_data()
-        .iter()
-        .map(|&sample| (sample * i16::MAX as f32) as i16)
-        .collect())
+            self.staged_frames.drain(..consumed_frames);
+            self.trim_startup_delay();
+        }
+
+        Ok(())
+    }
+
+    /// Resamples what is staged, flushes the filter, and returns the whole 16 kHz stream.
+    pub fn finish(mut self) -> Result<Vec<i16>, Box<dyn Error>> {
+        // The clip is as long as the ratio says, and the flush below pumps silence until
+        //  the output reaches that length.
+        let output_frame_count =
+            (self.resampler.resample_ratio() * self.input_frame_count as f64).ceil() as usize;
+
+        if !self.staged_frames.is_empty() {
+            self.resample_chunk(Some(self.staged_frames.len()))?;
+            self.staged_frames.clear();
+        }
+
+        while self.output.len() < output_frame_count {
+            self.resample_chunk(Some(0))?;
+        }
+
+        self.output.truncate(output_frame_count);
+
+        Ok(self.output)
+    }
+
+    // One call into the resampler over the staged frames, with what it produced appended
+    //  to the output. Reports how many input frames it took.
+    fn resample_chunk(&mut self, partial_frames: Option<usize>) -> Result<usize, Box<dyn Error>> {
+        let indexing = Indexing {
+            input_offset: 0,
+            output_offset: 0,
+            partial_len: partial_frames,
+            active_channels_mask: None,
+        };
+
+        let staged_frame_count = self.staged_frames.len();
+        let chunk_frame_count = self.chunk_output.len();
+
+        let input = InterleavedSlice::new(&self.staged_frames, CHANNEL_COUNT, staged_frame_count)?;
+        let mut output =
+            InterleavedSlice::new_mut(&mut self.chunk_output, CHANNEL_COUNT, chunk_frame_count)?;
+
+        let (consumed_frames, produced_frames) =
+            self.resampler
+                .process_into_buffer(&input, &mut output, Some(&indexing))?;
+
+        self.output.extend(
+            self.chunk_output[..produced_frames]
+                .iter()
+                .map(|&frame| (frame * i16::MAX as f32) as i16),
+        );
+
+        Ok(consumed_frames)
+    }
+
+    // The sinc filter answers with silence until it has seen enough input, and `rubato`
+    //  drops that silence from the front of the output once the output has outgrown it.
+    fn trim_startup_delay(&mut self) {
+        if self.frames_to_trim == 0 || self.output.len() <= self.frames_to_trim {
+            return;
+        }
+
+        // It moves `frames_to_trim` frames rather than all it holds, so those frames
+        //  arrive twice and nothing after them shifts. Trimmed properly, the first 46
+        //  frames of `probe.flac` changed and the golden URI no longer matched.
+        //  https://github.com/HEnquist/rubato/blob/6b72d0f9d8843c6623c818751730764aefcd0525/src/lib.rs#L363
+        let duplicated_frames = self.frames_to_trim..2 * self.frames_to_trim;
+
+        self.output.copy_within(duplicated_frames, 0);
+        self.output
+            .truncate(self.output.len() - self.frames_to_trim);
+        self.frames_to_trim = 0;
+    }
 }

--- a/tests/test_memory.py
+++ b/tests/test_memory.py
@@ -1,0 +1,106 @@
+"""Peak memory: fingerprinting must not scale with the length of the recording.
+
+The pipeline decodes, mixes down and resamples one packet at a time, so the only
+thing that grows with the source is the 16 kHz mono result the fingerprint reads.
+Held whole instead, a 30-minute stereo FLAC peaked at 1122188 KiB against 82200 KiB
+for the same file today, both measured with `/usr/bin/time -v`.
+
+The recording is written here rather than committed: five minutes of stereo is
+53 MB, and a file short enough to commit makes the difference invisible.
+"""
+
+import math
+import subprocess
+import sys
+import wave
+from array import array
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+_RECORDING_SECONDS: Final[int] = 300
+
+_SOURCE_RATE_HZ: Final[int] = 44100
+_SOURCE_CHANNEL_COUNT: Final[int] = 2
+
+_TONE_HZ: Final[int] = 440
+_TONE_AMPLITUDE: Final[int] = 12000
+
+_BYTES_PER_SAMPLE: Final[int] = 2
+_FINGERPRINT_RATE_HZ: Final[int] = 16000
+
+# What the pipeline may hold beyond an interpreter that only imported the extension:
+#  four times the 16 kHz mono stream of the recording, which leaves room for the segment
+#  copy and the allocator. Buffering the source instead costs seven times this bound.
+_PEAK_ALLOWANCE_KIB: Final[int] = (
+    4 * _RECORDING_SECONDS * _FINGERPRINT_RATE_HZ * _BYTES_PER_SAMPLE // 1024
+)
+
+# Each run reports its own `VmHWM`, the peak of the mapping `execve` gave it. Measured
+#  any other way it carries the caller's peak too: with 128 MiB held here, both runs
+#  below returned the same `ru_maxrss` of 145964 KiB and the difference was 0.
+#  https://github.com/torvalds/linux/blob/adc218676eef25575469234709c2d87185ca223a/fs/proc/task_mmu.c#L53
+_PEAK_REPORTER: Final[str] = """
+import asyncio
+import sys
+
+from shazamio_core import Recognizer
+
+
+async def main() -> None:
+    if len(sys.argv) > 1:
+        await Recognizer().recognize_path(sys.argv[1])
+
+
+asyncio.run(main())
+
+with open("/proc/self/status") as status:
+    print(next(line.split()[1] for line in status if line.startswith("VmHWM:")))
+"""
+
+
+def _write_recording(path: Path) -> None:
+    one_second = array(
+        "h",
+        [
+            int(_TONE_AMPLITUDE * math.sin(2 * math.pi * _TONE_HZ * frame / _SOURCE_RATE_HZ))
+            for frame in range(_SOURCE_RATE_HZ)
+            for _ in range(_SOURCE_CHANNEL_COUNT)
+        ],
+    )
+
+    with wave.open(str(path), "wb") as recording:
+        recording.setnchannels(_SOURCE_CHANNEL_COUNT)
+        recording.setsampwidth(_BYTES_PER_SAMPLE)
+        recording.setframerate(_SOURCE_RATE_HZ)
+
+        for _ in range(_RECORDING_SECONDS):
+            recording.writeframes(one_second.tobytes())
+
+
+def _peak_kibibytes(recording: Path | None = None) -> int:
+    arguments = [] if recording is None else [str(recording)]
+
+    completed = subprocess.run(
+        [sys.executable, "-c", _PEAK_REPORTER, *arguments],
+        capture_output=True,
+        check=True,
+        text=True,
+    )
+
+    return int(completed.stdout.strip())
+
+
+@pytest.mark.skipif(
+    sys.platform != "linux",
+    reason="`/proc/self/status` is where a process reports its own peak, and it is Linux only",
+)
+def test_fingerprinting_a_long_recording_holds_only_its_result(tmp_path: Path) -> None:
+    recording: Path = tmp_path / "long.wav"
+    _write_recording(recording)
+
+    baseline_peak = _peak_kibibytes()
+    fingerprint_peak = _peak_kibibytes(recording)
+
+    assert fingerprint_peak - baseline_peak < _PEAK_ALLOWANCE_KIB


### PR DESCRIPTION
## What

Fingerprinting held the whole recording several times over: every interleaved `f32` sample the decoder produced, a full-length mono copy of them, and a full-length `f32` resampler output before the `i16` conversion. `recognize_path` also read the file into memory before any of that.

The decoder now mixes down to mono packet by packet and feeds a resampling sink that appends `i16` as it goes, and a file is read through as it decodes. Nothing longer than one packet of the source exists beside the 16 kHz result.

Measured on a 30-minute stereo FLAC (44.1 kHz, 230 MB), the same file and the same command against both builds:

    $ /usr/bin/time -v uv run python fingerprint.py long.flac
    master  Maximum resident set size (kbytes): 1122188    Elapsed: 0:04.87
    branch  Maximum resident set size (kbytes):   82200    Elapsed: 0:03.90

The interpreter alone accounts for 36124 kB of that, so the pipeline holds about 46 MB against the 57.6 MB its own 16 kHz `i16` result needs.

The signature does not move. Both builds print the same URI for that file, and every pinned golden URI still matches:

    $ uv run python fingerprint.py long.flac | md5sum
    a431e8360cdfcf7d9ae989fde96b987d  -      # master
    a431e8360cdfcf7d9ae989fde96b987d  -      # branch

`tests/test_memory.py` pins this. It writes a five-minute stereo WAV and compares two child processes, one that only imports the extension and one that fingerprints the recording. On this branch the difference is 1628 KiB against an allowance of 37500 KiB; against `master`, on the same file, it is 171024 KiB, so the test fails there.

## What this does not cover

The resampler reproduces `rubato` 5.0.0's own startup-delay trim, defect included: it moves `output_delay()` frames rather than the whole valid region, so the first 46 frames at 44.1 kHz arrive twice and everything after them sits 46 frames late, about 2.9 ms. Trimming correctly changes every fingerprint, so it stays out of a change that is meant to move none of them.
https://github.com/HEnquist/rubato/blob/6b72d0f9d8843c6623c818751730764aefcd0525/src/lib.rs#L363

The memory test runs on Linux only: `ru_maxrss` is kilobytes there, bytes on macOS, and absent on Windows.

## How to test

`just all`. The interesting parts are the two golden URI tests and `tests/test_memory.py`.
