### PR TITLE
docs(readme): correct the examples, the format list and three dead pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,12 +75,23 @@ Ten seconds by default, taken from the middle of the file. A file shorter than t
 Set it per recognizer, or per call:
 
 ```python
-recognizer = Recognizer(segment_duration_seconds=5)
+import asyncio
 
-signature = await recognizer.recognize_path(
-    "track.mp3",
-    SearchParams(segment_duration_seconds=15),
-)
+from shazamio_core import Recognizer, SearchParams
+
+
+async def main() -> None:
+    recognizer = Recognizer(segment_duration_seconds=5)
+
+    signature = await recognizer.recognize_path(
+        "track.mp3",
+        SearchParams(segment_duration_seconds=15),
+    )
+
+    print(signature.signature.samples)
+
+
+asyncio.run(main())
 ```
 
 `SearchParams` wins where both are given. The duration must be at least 1; zero
@@ -92,12 +103,19 @@ whatever the value.
 Audio that cannot be decoded, and a file that is not there, raise `SignatureError`:
 
 ```python
+import asyncio
+
 from shazamio_core import Recognizer, SignatureError
 
-try:
-    await Recognizer().recognize_path("not-audio.txt")
-except SignatureError as error:
-    print(error)
+
+async def main() -> None:
+    try:
+        await Recognizer().recognize_path("not-audio.txt")
+    except SignatureError as error:
+        print(error)
+
+
+asyncio.run(main())
 ```
 
 ## Formats

--- a/README.md
+++ b/README.md
@@ -120,9 +120,33 @@ asyncio.run(main())
 
 ## Formats
 
-Decoding goes through [`symphonia`](https://github.com/pdeljanov/Symphonia) with every codec and container it ships enabled, and resampling to mono 16 kHz through [`rubato`](https://github.com/HEnquist/rubato). Opus is the one codec `symphonia` has no decoder for, so it goes through [`libopus`](https://github.com/SpaceManiac/opus-rs), which is compiled into the wheel rather than loaded from the system. Nothing is shelled out to, so no external binary has to be installed. The test suite covers MP3, Ogg Vorbis, Opus and FLAC on Linux, macOS and Windows.
+Decoding goes through [`symphonia`](https://github.com/pdeljanov/Symphonia) with every codec and container it ships enabled, and resampling to mono 16 kHz through [`rubato`](https://github.com/HEnquist/rubato). Opus is the one codec `symphonia` has no decoder for, so it goes through [`libopus`](https://github.com/SpaceManiac/opus-rs), which is compiled into the wheel rather than loaded from the system. Nothing is shelled out to, so no external binary has to be installed.
 
-One input is outside that set and raises `SignatureError`: Windows Media Audio in an ASF container. `symphonia` ships no ASF demuxer, and the `CODEC_TYPE_WMA` it declares has no decoder behind it. The format decoded in earlier releases through an `ffmpeg` fallback that has since been removed.
+That leaves these codecs, each one probed through the public API in the container named beside it:
+
+| Codec  | Probed in      | In the test suite |
+|--------|----------------|-------------------|
+| AAC    | ADTS           |                   |
+| ADPCM  | WAV            |                   |
+| ALAC   | MP4            |                   |
+| FLAC   | FLAC           | yes               |
+| MP1    | not probed     |                   |
+| MP2    | MPEG           |                   |
+| MP3    | MPEG           | yes               |
+| Opus   | Ogg            | yes               |
+| PCM    | WAV, AIFF, CAF |                   |
+| Vorbis | Ogg            | yes               |
+
+MP1 is the one row taken from what `symphonia` registers rather than from a run: nothing here encodes it. The containers recognised are ADTS, AIFF, CAF, FLAC, Matroska and WebM, MP4, MPEG, Ogg and WAV, and the test suite runs on Linux, macOS and Windows.
+
+Anything else raises `SignatureError`, and a container from that list is no guarantee: what has to be decodable is the codec inside it. The two refusals differ in how far the file gets:
+
+| Refused          | Error                        | Why                                     |
+|------------------|------------------------------|-----------------------------------------|
+| AC-3 in Matroska | `unsupported feature: codec` | the container is read, the codec is not |
+| WMA in ASF       | `end of stream`              | there is no ASF demuxer at all          |
+
+Windows Media Audio decoded in earlier releases through an `ffmpeg` fallback that has since been removed.
 
 ## Development
 

--- a/src/fingerprinting/algorithm.rs
+++ b/src/fingerprinting/algorithm.rs
@@ -446,9 +446,9 @@ mod tests {
 
     #[test]
     fn a_link_that_decodes_into_a_wider_buffer_decodes() {
-        // A decoder sizes its buffer once, so only a chained stream makes the sample
-        //  buffer grow. Vorbis holds 1024 frames here and the FLAC link after it 1152,
-        //  so 2304 samples land in a buffer of 2048 and `copy_interleaved_ref` panicked.
+        // The sample buffer used to be sized once, so a link needing a wider one panicked
+        //  in `copy_interleaved_ref`: 2304 samples into a buffer of 2048. How the fixture
+        //  chains its links: `tests/data/generate.sh`.
         let probe = decode_probe("chained_capacity.ogg").unwrap();
 
         assert_eq!(probe.channels, 2);

--- a/src/fingerprinting/signature_format.rs
+++ b/src/fingerprinting/signature_format.rs
@@ -45,8 +45,9 @@ impl DecodedSignature {
     pub fn encode_to_binary(&self) -> Result<Vec<u8>, Box<dyn Error>> {
         let mut cursor = Cursor::new(vec![]);
 
-        // Please see the RawSignatureHeader structure definition above for
-        // information about the following fields.
+        // The names below are the fields of `RawSignatureHeader` in the project this was
+        //  ported from, which says what each one holds. Only its decoder needed the struct.
+        //  https://github.com/marin-m/SongRec/blob/50b72aab457718fd0b2a814aa002149cea37453a/src/core/fingerprinting/signature_format.rs#L24
 
         cursor.write_u32::<LittleEndian>(0xcafe2580)?; // magic1
         cursor.write_u32::<LittleEndian>(0)?; // crc32 - Will write later


### PR DESCRIPTION
## What

Every `python` block in the `README` now runs as written. Two of them did not:
the compact form builds the future outside a loop, so it raised before any
recognition happened.

    $ python example-2.py
    Traceback (most recent call last):
      File "example-2.py", line 8, in <module>
        signature = asyncio.run(recognizer.recognize_path("track.mp3", ...))
    RuntimeError: no running event loop

Both are wrapped in an `async def main()` now, and all three blocks were
extracted from the file and run:

    example-1.py  True                                                              exit 0
    example-2.py  8000                                                              exit 0
    example-3.py  unsupported feature: core (probe): no suitable format reader found exit 0

The Formats section named one unsupported input and implied everything else
decodes. A supported container is no guarantee: what has to be decodable is the
codec inside it, and there are two distinct refusals. Generated a file per
format and ran each through the public API:

    aac.aac      ok       samples=3041      ac3.mkv    refused  unsupported feature: codec
    adpcm.wav    ok       samples=3006      wma.asf    refused  end of stream
    aiff.aiff    ok       samples=3000
    alac.m4a     ok       samples=3000
    mp2.mp2      ok       samples=3004
    pcm.caf      ok       samples=3000
    wav.wav      ok       samples=3000

The section now lists the codecs and containers `symphonia` is built with here,
and names both refusals: AC-3 in Matroska has no decoder, Windows Media Audio in
ASF has no demuxer, so it fails a step earlier.

Three pointers that no longer resolved:

- `signature_format.rs` said "please see the `RawSignatureHeader` structure
  definition above". No such struct exists in this crate: only a decoder needs
  it, and this one encodes. The comment now links the definition in the project
  this was ported from, pinned to a commit.
- The stub described the segment contract twice, in `SearchParams` and again in
  `Recognizer.__new__`. One home now, the other points at it.
- A test comment reproduced what `tests/data/generate.sh` says about how the
  chained fixture is built. It now names the script instead.

## How to test

`just all`. The examples are checked by reading them: copy each `python` block
out of the `README` and run it next to an audio file named `track.mp3`.
