### PR TITLE
chore(justfile): give the recipes one vocabulary and group them by what they do

### DIFF
--- a/.github/path-filters.yaml
+++ b/.github/path-filters.yaml
@@ -32,7 +32,7 @@ rust:
   - *harness
   - *crate
 
-# `Test`, which runs `just test` and `just stubtest`. The crate is in scope
+# `Test`, which runs `just test-python` and `just typecheck`. The crate is in scope
 #  because both exercise the built extension rather than the sources beside it.
 python:
   - *harness

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -93,16 +93,16 @@ jobs:
       - uses: ./.github/actions/setup-just
 
       - name: Install the project and its test dependencies
-        run: just sync
+        run: just install-test
 
       - name: Run the tests
-        run: just test
+        run: just test-python
 
       # The stub does not vary by platform, so one runner answers for all three. Why
-      #  the check exists at all: the `stubtest` recipe.
+      #  the check exists at all: the `typecheck` recipe.
       - name: Check the type stub against the built extension
         if: matrix.os == 'ubuntu-latest'
-        run: just stubtest
+        run: just typecheck
 
   # Byte layout, checksum, band ordering: none of that varies by platform, so one
   #  runner answers for all of them -- whether the fingerprint itself does is what
@@ -126,7 +126,7 @@ jobs:
       - uses: ./.github/actions/setup-just
 
       - name: Run the unit tests
-        run: just rust-test
+        run: just test-rust
 
   # Neither of the two gates the recipe runs is provided by anything else here: the
   #  wheel jobs compile the crate, and a compiler is indifferent to formatting and to

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,10 +42,10 @@ repos:
         files: ^(\.pre-commit-config\.yaml|justfile|src/.*|Cargo\.(toml|lock))$
         pass_filenames: false
 
-      - id: rust-test
+      - id: test-rust
         name: rust · unit tests
         entry: just
-        args: [rust-test]
+        args: [test-rust]
         language: system
         files: ^(\.pre-commit-config\.yaml|justfile|src/.*|Cargo\.(toml|lock))$
         pass_filenames: false
@@ -62,18 +62,18 @@ repos:
 
       # The crate is in scope for both because they exercise the built extension;
       #  `tool.uv.cache-keys` in `pyproject.toml` is what rebuilds it.
-      - id: test
+      - id: test-python
         name: python · pytest
         entry: just
-        args: [test]
+        args: [test-python]
         language: system
         files: ^(\.pre-commit-config\.yaml|justfile|src/.*|Cargo\.(toml|lock)|tests/.*|shazamio_core/.*|pyproject\.toml|uv\.lock)$
         pass_filenames: false
 
-      - id: stubtest
+      - id: typecheck
         name: python · stub against the built extension
         entry: just
-        args: [stubtest]
+        args: [typecheck]
         language: system
         files: ^(\.pre-commit-config\.yaml|justfile|src/.*|Cargo\.(toml|lock)|tests/.*|shazamio_core/.*|pyproject\.toml|uv\.lock)$
         pass_filenames: false

--- a/README.md
+++ b/README.md
@@ -155,14 +155,14 @@ Every check CI runs is a [`just`](https://github.com/casey/just) recipe, so the 
 ```sh
 just --list      # what there is
 just install     # builds the extension, installs the test dependencies, `cargo-about` and the commit hooks
-just all         # everything CI gates on
+just ci          # everything CI gates on
 ```
 
 `just install` also wires the same recipes into `git commit` through [`pre-commit`](https://pre-commit.com), each one scoped to the files it gates, so a change to the `README` runs none of them and a change to the crate runs all of them. CI scopes its jobs the same way, from the same sets: `.github/path-filters.yaml`.
 
 `just install` needs the toolchain the Install section lists; `maturin` comes from `pyproject.toml` and is fetched automatically. `just` itself is packaged for most systems, listed under [Packages](https://github.com/casey/just#packages).
 
-`just rust-test` links `libpython`, so on Debian and Ubuntu the development package of the interpreter `cargo` picks up has to be present, or the build stops at `rust-lld: error: unable to find library -lpython3.14`:
+`just test-rust` links `libpython`, so on Debian and Ubuntu the development package of the interpreter `cargo` picks up has to be present, or the build stops at `rust-lld: error: unable to find library -lpython3.14`:
 
 ```sh
 sudo apt install libpython3.14-dev

--- a/justfile
+++ b/justfile
@@ -20,8 +20,13 @@ notices := "THIRD-PARTY-NOTICES.md"
 default:
     @just --list
 
-[doc("Build the extension into the environment and install the test dependencies")]
-sync:
+# --- Setup ---
+
+# Separate from `install` because the CI test matrix wants the environment and
+#  nothing else: `cargo-about` and the hook environments cost minutes on each of
+#  the three runners, and neither is used to run a test.
+[doc("The environment the tests need: the dependencies and the built extension")]
+install-test:
     uv sync
 
 # `--install-hooks` builds the hook environments now instead of during whichever
@@ -32,28 +37,11 @@ sync:
 #  only in a warning, because the `cargo-about` binary sits behind that feature.
 #  https://github.com/EmbarkStudios/cargo-about/blob/f7394d5c8f618623573072caadf6594821c789b6/Cargo.toml#L23-L26
 [doc("Everything a checkout needs: the dependencies, `cargo-about` and the `pre-commit` hooks")]
-install: sync
+install: install-test
     cargo install cargo-about --locked --features cli --version '={{ cargo_about_version }}'
     uv run pre-commit install --install-hooks
 
-[doc("Run the Python test suite")]
-test:
-    uv run pytest
-
-# Nothing else compares the hand-written `.pyi` with the extension, and it had
-#  drifted: `Recognizer.__init__` declared a parameter the runtime carries on
-#  `__new__`, and three classes claimed to be `@dataclass`.
-[doc("Check the type stub against the built extension")]
-stubtest:
-    uv run python -m mypy.stubtest shazamio_core.shazamio_core
-
-[doc("Run the Rust unit tests")]
-rust-test:
-    cargo test
-
-[doc("Reformat the crate")]
-fmt:
-    cargo fmt --all
+# --- Code quality ---
 
 # `--all-targets` is what reaches the `#[cfg(test)]` modules. The default target
 #  set stops at the library, so every unit test would go unlinted.
@@ -62,6 +50,32 @@ fmt:
 lint:
     cargo fmt --all --check
     cargo clippy --all-targets -- -D warnings
+
+[doc("Reformat the crate")]
+format:
+    cargo fmt --all
+
+# Nothing else compares the hand-written `.pyi` with the extension, and it had
+#  drifted: `Recognizer.__init__` declared a parameter the runtime carries on
+#  `__new__`, and three classes claimed to be `@dataclass`.
+[doc("Check the type stub against the built extension")]
+typecheck:
+    uv run python -m mypy.stubtest shazamio_core.shazamio_core
+
+# --- Tests ---
+
+[doc("Run both suites")]
+test: test-rust test-python
+
+[doc("Run the Python suite; extra arguments reach `pytest`")]
+test-python *args:
+    uv run pytest {{ args }}
+
+[doc("Run the Rust suite; extra arguments reach `cargo test`")]
+test-rust *args:
+    cargo test {{ args }}
+
+# --- Release ---
 
 # Everything else builds with current stable, so a `cargo update` can raise the
 #  real floor and stay green. Whoever builds the sdist on a distro toolchain is
@@ -106,5 +120,7 @@ licenses-check:
     just licenses "$generated"
     diff -u {{ notices }} "$generated"
 
+# --- CI ---
+
 [doc("Everything CI gates on; the first run downloads the MSRV toolchain")]
-all: lint rust-test test stubtest msrv licenses-check
+ci: lint typecheck test msrv licenses-check


### PR DESCRIPTION
## What

The recipes had grown three vocabularies at once. `sync`, `fmt` and `all` sat
beside `install` and `lint`; `test` meant the Python suite alone, while the Rust
one and the stub check were named after the tool that runs them rather than the
job they do. Neither test recipe took arguments, so narrowing a run meant
dropping out of `just` and retyping the command with its flags.

`just --list` before:

    all                     # Everything CI gates on; the first run downloads the MSRV toolchain
    default                 # Show the recipes
    fmt                     # Reformat the crate
    install                 # Everything a checkout needs: the dependencies, `cargo-about` and the `pre-commit` hooks
    licenses output=notices # Regenerate the third-party licence notices from `Cargo.lock`
    licenses-check          # Check the committed notices still match `Cargo.lock`
    lint                    # Check the formatting and run `clippy`
    msrv                    # Check the crate against the Rust version it declares
    rust-test               # Run the Rust unit tests
    stubtest                # Check the type stub against the built extension
    sync                    # Build the extension into the environment and install the test dependencies
    test                    # Run the Python test suite

and after:

    ci                      # Everything CI gates on; the first run downloads the MSRV toolchain
    default                 # Show the recipes
    format                  # Reformat the crate
    install                 # Everything a checkout needs: the dependencies, `cargo-about` and the `pre-commit` hooks
    install-test            # The environment the tests need: the dependencies and the built extension
    licenses output=notices # Regenerate the third-party licence notices from `Cargo.lock`
    licenses-check          # Check the committed notices still match `Cargo.lock`
    lint                    # Check the formatting and run `clippy`
    msrv                    # Check the crate against the Rust version it declares
    test                    # Run both suites
    test-python *args       # Run the Python suite; extra arguments reach `pytest`
    test-rust *args         # Run the Rust suite; extra arguments reach `cargo test`
    typecheck               # Check the type stub against the built extension

Two of those are more than a rename:

* `test` now runs both suites instead of only the Python one, so the name
  matches what a reader expects of it. The per-language runs are `test-python`
  and `test-rust`.
* `install-test` is the environment alone, split out because the test matrix
  needs it on three runners and has no use for `cargo-about` or the hook
  environments, both of which cost minutes.

Passthrough arguments are new on both test recipes:

    $ just test-python -k memory -q
    1 passed, 23 deselected

    $ just test-rust params
    2 passed; 40 filtered out

The file is also grouped into sections, since `just --list` sorts
alphabetically and the file itself is the only place the recipes appear in an
order that means anything.

The callers move with the names: the three local hook ids in
`.pre-commit-config.yaml`, four `run:` steps in the CI workflow, and the
comment in `.github/path-filters.yaml` that names the recipes its `Test` filter
gates.

## How to test

`just ci`, which is the old `just all` under its house name.
