### PR TITLE
build(cargo): declare what the source distribution ships with `include`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,36 @@ license = "MIT"
 # `rubato` 5 declares 1.87 and is the highest floor in the tree; `pyo3` 0.29 asks for
 #  1.83 and nothing else asks for more.
 rust-version = "1.87"
+# What the source distribution carries, whitelisted so a new file has to be named
+#  here to ship. It leaves out what only the repository uses: the workflows, the
+#  wheel image, the commit hooks, the lock file of the test tooling. The tests and
+#  their audio stay, because a source build is the install path wherever no wheel
+#  exists and whoever takes it has to run the suite on the platform they built for.
+#  https://packaging.python.org/en/latest/discussions/downstream-packaging/
+#  `Cargo.toml`, `Cargo.lock` and `pyproject.toml` are added by the build regardless.
+#
+#  Every pattern is anchored because `include` overrides `.gitignore`: a bare
+#  `LICENSE` matched the 54 of them under `.venv/` and `.pytest_cache/` too.
+#  https://doc.rust-lang.org/cargo/reference/manifest.html#the-exclude-and-include-fields
+include = [
+    # The crate, and the Python package the built extension is loaded from.
+    "/src/**/*.rs",
+    "/shazamio_core/**",
+    "/tests/**",
+    # How the suite above is run, and the one record of what a source build should
+    #  pass before it is trusted.
+    "/justfile",
+    # Removing it fails the build before the compiler is reached: `Failed to read
+    #  Readme specified in Cargo.toml, which should be at <root>/README.md`.
+    "/README.md",
+    # Both are named in `license-files` in `pyproject.toml`, so they carry into the
+    #  metadata of the wheel a source build produces.
+    "/LICENSE",
+    "/THIRD-PARTY-NOTICES.md",
+    # The generator of the notices above, and what the shipped `justfile` reads in
+    #  `licenses-check`: without it that recipe and `ci` fail on a missing file.
+    "/licenses/**",
+]
 
 [lib]
 name = "shazamio_core"


### PR DESCRIPTION
## What

The source distribution shipped whatever `.gitignore` did not exclude, so every
release carried the CI workflows, the manylinux build image, the commit hooks and
the lock file of the test tooling. `Cargo.toml` now declares an `include`
whitelist, so a new file has to be named there before it ships.

Built from `master` and from this branch, the two archives differ by ten files and
nothing else:

    $ tar tzf shazamio_core-1.2.0.tar.gz | grep -v '/$' | wc -l
    52      # master
    42      # this branch

    .github/actions/setup-just/action.yml
    .github/dependabot.yml
    .github/path-filters.yaml
    .github/workflows/ci.yaml
    .gitignore
    .pre-commit-config.yaml
    docker/Dockerfile
    docker/build-manylinux.sh
    docker/install-basic-deps-manylinux.sh
    uv.lock

1492922 bytes to 1446519. The size is not the point: the audio fixtures are 1.4 MB
of the archive and they stay.

## Why

The tests, their audio and the `justfile` stay because a source build is the
install path wherever no wheel exists, and whoever takes that path has to be able
to run the suite on the platform they built for.
https://packaging.python.org/en/latest/discussions/downstream-packaging/

The licence notice generator stays for the same reason: `THIRD-PARTY-NOTICES.md`
ships, and `just licenses-check` reads `licenses/about.toml` and `licenses/notices.hbs`,
so both that recipe and `just ci` failed on a missing file inside the archive
while they were excluded.

`uv.lock` goes, because it pins the test tooling rather than anything the build
reads: an install from the archive never opens it, and a distribution packager
uses their own dependency versions.

## How to test

    maturin sdist -o dist
    tar xzf dist/shazamio_core-1.2.0.tar.gz -C /tmp
    cd /tmp/shazamio_core-1.2.0
    just licenses-check
    pip wheel . -w /tmp/wheels

Run the shipped suite against that wheel from outside the unpacked tree. Starting
`pytest` inside it makes the flat-layout `shazamio_core/` directory shadow the
installed package, which has the compiled extension in it, and every import fails.
