### PR TITLE
build(metadata): give the crate a description and a repository, and derive the `Summary` from them

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,14 @@
 name = "shazamio-core"
 version = "1.2.0"
 edition = "2021"
+# The one copy: `pyproject.toml` lists `description` in `dynamic` and `maturin`
+#  takes it from here, where it becomes the `Summary` of the Python distribution.
+description = "Audio fingerprinting for Shazam, written in Rust and exposed to Python"
+# Without one of `documentation`, `homepage` or `repository` every build prints
+#  `manifest has no documentation, homepage or repository`. `[project.urls]` names
+#  this address again because `cargo` has no field for an issue tracker, and making
+#  `urls` dynamic too would drop that link from the distribution metadata.
+repository = "https://github.com/shazamio/shazamio-core"
 # Same expression `pyproject.toml` declares. It is here because the licence
 #  harvesting the `licenses` recipe runs reads crate metadata, and warns on
 #  every run about a crate that declares none.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -1158,7 +1158,7 @@ SOFTWARE.
 
 ## MIT License
 
-- `shazamio-core 1.2.0`
+- `shazamio-core 1.2.0` (https://github.com/shazamio/shazamio-core)
 
 ```text
 MIT License

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,9 +29,12 @@ build-backend = "maturin"
 
 [project]
 name = "shazamio_core"
-description = "Audio fingerprinting for Shazam, written in Rust and exposed to Python"
 readme = "README.md"
 # `Cargo.toml` declares the same expression, and says why it needs its own copy.
+#  Deriving this one from there instead, by naming `license` in `dynamic` the way
+#  `description` is, emits the deprecated `License: MIT` field in place of
+#  `License-Expression: MIT`.
+#  https://peps.python.org/pep-0639/#deprecate-license-field
 license = "MIT"
 # `THIRD-PARTY-NOTICES.md` is generated; `just licenses` writes it and the
 #  `licenses` check fails when it no longer matches `Cargo.lock`.
@@ -47,7 +50,10 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]
-dynamic = ["version"]
+# `maturin` may only fill a field named here, so `description` has to be listed to
+#  reach the metadata at all: left out, the distribution ships with no `Summary`.
+#  https://www.maturin.rs/metadata
+dynamic = ["version", "description"]
 
 [project.urls]
 Repository = "https://github.com/shazamio/shazamio-core"


### PR DESCRIPTION
## What

`Cargo.toml` carried nothing beyond the name, the version and the licence, so every
build said so:

    $ cargo package --list
    warning: manifest has no description, documentation, homepage or repository
      |
      = note: see https://doc.rust-lang.org/cargo/reference/manifest.html#package-metadata for more info

The crate now declares `description` and `repository`, and both `cargo package` and
`maturin sdist` are quiet. `description` alone is not enough: the warning comes back
as `manifest has no documentation, homepage or repository`, which is why the
repository address is there too.

The description is not a second copy. `pyproject.toml` stops stating it and names
`description` in `dynamic` instead, which is what lets the backend fill it from the
crate. The two metadata fields that could have moved are unchanged, in the sdist
`PKG-INFO` and in the wheel `METADATA` alike:

    Summary: Audio fingerprinting for Shazam, written in Rust and exposed to Python
    License-Expression: MIT

Naming it in `dynamic` is what makes that work rather than a formality: with the
field left out, the distribution ships with no `Summary` at all.
https://www.maturin.rs/metadata

`THIRD-PARTY-NOTICES.md` is regenerated in the same commit, because the generator
prints the crate address once the crate declares one:

    - - `shazamio-core 1.2.0`
    + - `shazamio-core 1.2.0` (https://github.com/shazamio/shazamio-core)

## Why

Two things that look like they should derive the same way, and do not:

The licence stays stated in both manifests, each side pointing at the other. Naming
`license` in `dynamic` was tried: it emits the deprecated `License: MIT` field in
place of `License-Expression: MIT`, and the legacy field is exactly what the current
specification replaced.
https://peps.python.org/pep-0639/#deprecate-license-field

`[project.urls]` stays in `pyproject.toml`. Making `urls` dynamic works and pulls the
addresses out of the crate, but `cargo` has no field for an issue tracker, so the
`Issues` link disappears and `Repository` is relabelled `Source Code`.

## How to test

    cargo package --list | grep warning        # nothing
    just licenses-check                        # notices match the crate metadata
    maturin sdist -o dist
    tar xzOf dist/shazamio_core-1.2.0.tar.gz '*/PKG-INFO' | grep '^Summary\|^License'
