### PR TITLE
build(licenses): keep the project's own crate out of the third-party notices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ description = "Audio fingerprinting for Shazam, written in Rust and exposed to P
 #  this address again because `cargo` has no field for an issue tracker, and making
 #  `urls` dynamic too would drop that link from the distribution metadata.
 repository = "https://github.com/shazamio/shazamio-core"
+# Nothing publishes this crate: the wheel is what ships. `licenses/about.toml` reads
+#  the field to keep our own licence out of the third-party notices.
+publish = false
 # Same expression `pyproject.toml` declares. It is here because the licence
 #  harvesting the `licenses` recipe runs reads crate metadata, and warns on
 #  every run about a crate that declares none.

--- a/THIRD-PARTY-NOTICES.md
+++ b/THIRD-PARTY-NOTICES.md
@@ -15,7 +15,7 @@ from is named beside it. None of them is patched here.
 
 Crates per licence:
 
-- MIT License (`MIT`): 77
+- MIT License (`MIT`): 76
 - Mozilla Public License 2.0 (`MPL-2.0`): 17
 - Apache License 2.0 (`Apache-2.0`): 2
 - BSD 3-Clause "New" or "Revised" License (`BSD-3-Clause`): 2
@@ -1135,35 +1135,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLI
 MIT License
 
 Copyright (c) 2024 Daniel Henry-Mantilla
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
-
-```
-
-## MIT License
-
-- `shazamio-core 1.2.0` (https://github.com/shazamio/shazamio-core)
-
-```text
-MIT License
-
-Copyright (c) 2024 dotX12
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/licenses/about.toml
+++ b/licenses/about.toml
@@ -18,6 +18,13 @@ accepted = [
 ignore-build-dependencies = true
 ignore-dev-dependencies = true
 
+# The root crate is harvested like any dependency, so a file of third-party notices
+#  listed this project among them, and the paragraph promising every crate below is
+#  published on `crates.io` was false for that row: it is not published anywhere.
+#  `ignore` drops a workspace member that publishes nowhere.
+#  https://embarkstudios.github.io/cargo-about/cli/generate/config.html
+private = { ignore = true }
+
 # The six targets the wheels are built for, so a crate pulled in by a `cfg()`
 #  none of them match stays out of the notices. Canonical list:
 #  `.github/workflows/ci.yaml`.


### PR DESCRIPTION
## What

`THIRD-PARTY-NOTICES.md` listed this project among the third parties, because the
generator harvests the root crate the same way it harvests a dependency. Two lines
of configuration drop it, and the file is regenerated:

    - MIT License (`MIT`): 77          # before
    - MIT License (`MIT`): 76          # after

    - - `shazamio-core 1.2.0` (https://github.com/shazamio/shazamio-core)
    - -
    - - ```text
    - - MIT License
    - - Copyright (c) 2024 dotX12
    - - ...
    (30 lines, our own licence text and its heading)

Nothing is lost: the project's licence is `LICENSE`, which ships in the wheel and in
the source distribution, and the notices file already points at it.

## Why

The file states, in the paragraph that explains how it satisfies section 3.2(a) of
the Mozilla Public License 2.0:

> Every crate below is published on `crates.io`, its unmodified source is at
> `https://crates.io/crates/<name>/<version>`

That was false for exactly one row. This crate is not published anywhere:

    $ curl -H 'User-Agent: ...' https://crates.io/api/v1/crates/shazamio-core
    {"errors":[{"detail":"crate `shazamio-core` does not exist"}]}

A source-availability statement is the wrong place for a claim that does not hold,
so the row goes rather than the sentence being weakened.

`publish = false` is what the generator keys on, and it is true independently: the
wheel is what ships, and it also stops `cargo publish` from ever running by accident.
https://embarkstudios.github.io/cargo-about/cli/generate/config.html

## How to test

    just licenses-check                        # regenerates and diffs, no output
    grep -c '^## ' THIRD-PARTY-NOTICES.md      # 39, was 40
