### PR TITLE
ci(dist): check what the release archives contain before publishing them

### DIFF
--- a/.github/path-filters.yaml
+++ b/.github/path-filters.yaml
@@ -43,10 +43,11 @@ python:
   - uv.lock
 
 # `windows`, `macos`, `linux` and `sdist`, which build what a release publishes and
-#  check what came out of it. The notices are in that set: `pyproject.toml` ships
-#  them beside `LICENSE`, so editing them changes what every wheel contains. So are
-#  the package directory and the checker itself: `dist-check` requires the stub and
-#  `py.typed`, and a deletion there would otherwise reach a release unchecked.
+#  check what came out of it. The notices are in the set because `pyproject.toml`
+#  ships them beside `LICENSE`; `shazamio_core/` and `scripts/` are in it because
+#  `dist-check` reads the stub, `py.typed` and its own script. Globbed where
+#  `include` in `Cargo.toml` names one file: that one decides what is published,
+#  this one only decides what re-runs, and too narrow here skips a job in silence.
 dist:
   - *harness
   - *crate

--- a/.github/path-filters.yaml
+++ b/.github/path-filters.yaml
@@ -42,14 +42,18 @@ python:
   - pyproject.toml
   - uv.lock
 
-# `windows`, `macos`, `linux` and `sdist`, which build what a release publishes.
-#  The notices are in that set: `pyproject.toml` ships them beside `LICENSE`, so
-#  editing them changes what every wheel contains.
+# `windows`, `macos`, `linux` and `sdist`, which build what a release publishes and
+#  check what came out of it. The notices are in that set: `pyproject.toml` ships
+#  them beside `LICENSE`, so editing them changes what every wheel contains. So are
+#  the package directory and the checker itself: `dist-check` requires the stub and
+#  `py.typed`, and a deletion there would otherwise reach a release unchecked.
 dist:
   - *harness
   - *crate
   - pyproject.toml
   - docker/**
+  - shazamio_core/**
+  - scripts/**
   - THIRD-PARTY-NOTICES.md
 
 # `Licence notices`, which regenerates them and diffs against the committed file.

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
   # `pull_request` builds the branch merged with `master` as it stood when the run
   #  started, so two branches that are each green can still land a tree nobody ever
-  #  compiled -- which is how `d743ebb` reached `master` failing `cargo test` with
+  #  compiled, which is how `d743ebb` reached `master` failing `cargo test` with
   #  `error[E0308]: mismatched types`. Only a run on the merged result catches that.
   push:
     branches:
@@ -20,8 +20,8 @@ on:
 # Every `uses:` below is pinned to a commit SHA, with its version in the comment
 #  beside it. A tag is mutable: whoever owns the action can move `v7` onto another
 #  commit, and it then runs with the `contents: write` granted here and with the
-#  PyPI token the `release` job passes in. Dependabot keeps the pins current --
-#  see `.github/dependabot.yml`.
+#  PyPI token the `release` job passes in. Dependabot keeps the pins current, see
+#  `.github/dependabot.yml`.
 #  https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions
 permissions:
   contents: write
@@ -36,10 +36,9 @@ env:
   MATURIN_VERSION: v1.14.1
 
 # Every command below lives in the `justfile`, so a local check and a CI job are one
-#  string rather than two copies that drift. Four jobs need `just`, so getting it is
-#  a local composite action rather than four copies of the same two commands:
+#  string rather than two copies that drift. Most jobs need `just`, so getting it is
+#  a local composite action rather than one copy of the same two commands per job:
 #  `.github/actions/setup-just`.
-
 jobs:
   # A `paths:` filter on the trigger skips the whole workflow, and a required check
   #  belonging to a run that never happened stays pending forever. A job skipped by
@@ -105,8 +104,8 @@ jobs:
         run: just typecheck
 
   # Byte layout, checksum, band ordering: none of that varies by platform, so one
-  #  runner answers for all of them -- whether the fingerprint itself does is what
-  #  the job above exists for.
+  #  runner answers for all of them. Whether the fingerprint itself does is what the
+  #  job above exists for.
   rust-test:
     name: Rust unit tests
     needs: changes
@@ -156,41 +155,48 @@ jobs:
   #  up. There is no per-interpreter matrix any more, so a new CPython release
   #  needs no change here and no new release. The floor lives in `Cargo.toml`.
   windows:
-   needs: changes
-   if: needs.changes.outputs.dist == 'true'
-   runs-on: windows-latest
-   strategy:
-     matrix:
-       target: [ x64, x86 ]
-   steps:
-     - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-     # The version is deliberately unpinned: under abi3 the wheel is the same
-     # whichever CPython builds it, and a pinned one would need editing again the
-     # day it goes end-of-life. The step itself has to stay for the x86 target --
-     # pyo3 does not treat 32-bit-on-64-bit Windows as cross-compilation, so it
-     # reads the host interpreter's config and needs a 32-bit one to be present.
-     # https://github.com/PyO3/pyo3/blob/v0.29.2/pyo3-build-config/src/impl_.rs#L1675-L1679
-     - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
-       with:
-         python-version: "3.x"
-         architecture: ${{ matrix.target }}
-     - name: Build wheels
-       uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
-       with:
-         maturin-version: ${{ env.MATURIN_VERSION }}
-         target: ${{ matrix.target }}
-         args: --release --out dist
-         sccache: "true"
-     - uses: ./.github/actions/setup-just
-     - name: Check what the wheels carry
-       run: just dist-check
-     - name: Upload wheels
-       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-       with:
-         name: wheels-${{ runner.os }}-${{ matrix.target }}
-         path: dist
-#
+    name: Wheel (windows ${{ matrix.target }})
+    needs: changes
+    if: needs.changes.outputs.dist == 'true'
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        target: [ x64, x86 ]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      # The version is deliberately unpinned: under abi3 the wheel is the same
+      #  whichever CPython builds it, and a pinned one would need editing again the
+      #  day it goes end-of-life. The step itself has to stay for the x86 target:
+      #  pyo3 does not treat 32-bit-on-64-bit Windows as cross-compilation, so it
+      #  reads the host interpreter's config and needs a 32-bit one to be present.
+      #  https://github.com/PyO3/pyo3/blob/v0.29.2/pyo3-build-config/src/impl_.rs#L1675-L1679
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.x"
+          architecture: ${{ matrix.target }}
+
+      - name: Build wheels
+        uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
+        with:
+          maturin-version: ${{ env.MATURIN_VERSION }}
+          target: ${{ matrix.target }}
+          args: --release --out dist
+          sccache: "true"
+
+      - uses: ./.github/actions/setup-just
+
+      - name: Check what the wheels carry
+        run: just dist-check
+
+      - name: Upload wheels
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: wheels-${{ runner.os }}-${{ matrix.target }}
+          path: dist
+
   macos:
+    name: Wheel (${{ matrix.target }})
     needs: changes
     if: needs.changes.outputs.dist == 'true'
     strategy:
@@ -201,13 +207,14 @@ jobs:
             target: x86_64-apple-darwin
           - os: macos-latest
             target: aarch64-apple-darwin
-
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.x"
+
       - name: Build wheels
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
@@ -215,7 +222,9 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist
           sccache: "true"
+
       - uses: ./.github/actions/setup-just
+
       - name: Check what the wheels carry
         run: just dist-check
 
@@ -226,6 +235,7 @@ jobs:
           path: dist
 
   linux:
+    name: Wheel (${{ matrix.name }})
     needs: changes
     if: needs.changes.outputs.dist == 'true'
     strategy:
@@ -263,19 +273,19 @@ jobs:
           # A pull request's cache is scoped to `refs/pull/N/merge`, which neither `master`
           #  nor another pull request can read, so each one exported a full image of layers
           #  nobody could reuse. That held the repository over the 10 GB limit, and eviction
-          #  is oldest-first, so the x86 image lost its layers before the next run read them
-          #  -- 0 cached layers, and 224s of a 441s build step spent re-exporting them.
+          #  is oldest-first, so the x86 image lost its layers before the next run read
+          #  them: 0 cached layers, and 224s of a 441s build step spent re-exporting them.
           #  https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching
           cache-to: ${{ github.ref == 'refs/heads/master' && format('type=gha,mode=max,scope={0}', matrix.name) || '' }}
           context: .
 
-      - name: List /opt/dist directory
+      - name: List the wheels the image built
         run: docker run --rm shazamio_core ls -la /opt/dist
 
-      - name: Copy wheels
+      - name: Copy the wheels out of the image
         run: docker run --rm -v $(pwd)/dist:/tmp shazamio_core sh -c "cp -R /opt/dist/* /tmp/"
 
-      - name: Debug List files in /tmp after copy
+      - name: List the wheels that were copied
         run: ls -la dist
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
@@ -284,24 +294,26 @@ jobs:
 
       # The build image carries every library the wheel could have linked against;
       #  this runner carries none of them, and it is the same architecture the wheel
-      #  targets. Installing here is what proves the wheel works where users are --
+      #  targets. Installing here is what proves the wheel works where users are, and
       #  nothing else in this workflow ever runs what it publishes.
-      #  `--find-links` rather than a glob: `dist/` holds the PyPy wheel as well, and
-      #  naming both on one `pip install` fails as unsupported on this interpreter.
-      #  Resolving by name also fails if the wheel carries the wrong platform tags.
       - name: Check the wheel installs and imports outside the build image
         run: |
+          # `--find-links` rather than a glob: `dist/` holds the PyPy wheel as well,
+          #  and naming both on one `pip install` fails as unsupported on this
+          #  interpreter. Resolving by name also fails if the wheel carries the
+          #  wrong platform tags.
           pip install --no-index --find-links dist shazamio_core
 
           # `python -c` puts the working directory first on `sys.path`, so from the
           #  repository root this imported `shazamio_core/` out of the source tree
-          #  instead of the wheel just installed -- and passed, for as long as that
+          #  instead of the wheel just installed, and passed for as long as that
           #  directory held a Python stub next to the extension. `$RUNNER_TEMP` keeps
           #  the source tree off the path, so the import can only resolve to the wheel.
           cd "$RUNNER_TEMP"
           python -c "import shazamio_core; print(shazamio_core.__file__)"
 
       - uses: ./.github/actions/setup-just
+
       - name: Check what the wheels carry
         run: just dist-check
 
@@ -312,18 +324,22 @@ jobs:
           path: dist
 
   sdist:
+    name: Source distribution
     needs: changes
     if: needs.changes.outputs.dist == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
       - name: Build sdist
         uses: PyO3/maturin-action@e83996d129638aa358a18fbd1dfb82f0b0fb5d3b # v1.51.0
         with:
           maturin-version: ${{ env.MATURIN_VERSION }}
           command: sdist
           args: --out dist
+
       - uses: ./.github/actions/setup-just
+
       - name: Check what the archive carries
         run: just dist-check
 
@@ -399,9 +415,9 @@ jobs:
 
   release:
     name: Release
+    needs: [ test, rust-test, lint, windows, macos, linux, sdist, licenses ]
+    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
-    if: "startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'"
-    needs: [ test, rust-test, lint, licenses, sdist, macos, linux, windows ]
     steps:
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -326,6 +326,28 @@ jobs:
       - uses: ./.github/actions/setup-just
       - name: Check what the archive carries
         run: just dist-check
+
+      # The registry and not `target/`, and written only from `master`: both are the
+      #  10 GB cache limit this repository has already gone over once, which the
+      #  `cache-to` line of the `linux` job argues. A pull request would export a
+      #  release `target/` nothing else can read, and it is the largest thing here.
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
+        with:
+          cache-targets: "false"
+          save-if: ${{ github.ref == 'refs/heads/master' }}
+
+      # Nothing else opens the archive, and it is the install path wherever no wheel
+      #  exists. `install-test` compiles the crate through the PEP 517 backend, so an
+      #  `include` that dropped a source file or a fixture fails here instead of in
+      #  somebody's terminal. It resolves without `uv.lock`, which the archive omits.
+      - name: Check a wheel builds out of the archive and its suite passes
+        run: |
+          tar -xzf dist/*.tar.gz -C "$RUNNER_TEMP"
+          cd "$RUNNER_TEMP"/shazamio_core-*
+
+          just install-test
+          just test-python
+
       - name: Upload sdist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -181,6 +181,9 @@ jobs:
          target: ${{ matrix.target }}
          args: --release --out dist
          sccache: "true"
+     - uses: ./.github/actions/setup-just
+     - name: Check what the wheels carry
+       run: just dist-check
      - name: Upload wheels
        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
        with:
@@ -212,6 +215,10 @@ jobs:
           target: ${{ matrix.target }}
           args: --release --out dist
           sccache: "true"
+      - uses: ./.github/actions/setup-just
+      - name: Check what the wheels carry
+        run: just dist-check
+
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -294,6 +301,10 @@ jobs:
           cd "$RUNNER_TEMP"
           python -c "import shazamio_core; print(shazamio_core.__file__)"
 
+      - uses: ./.github/actions/setup-just
+      - name: Check what the wheels carry
+        run: just dist-check
+
       - name: Upload wheels
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
@@ -312,6 +323,9 @@ jobs:
           maturin-version: ${{ env.MATURIN_VERSION }}
           command: sdist
           args: --out dist
+      - uses: ./.github/actions/setup-just
+      - name: Check what the archive carries
+        run: just dist-check
       - name: Upload sdist
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -279,14 +279,8 @@ jobs:
           cache-to: ${{ github.ref == 'refs/heads/master' && format('type=gha,mode=max,scope={0}', matrix.name) || '' }}
           context: .
 
-      - name: List the wheels the image built
-        run: docker run --rm shazamio_core ls -la /opt/dist
-
       - name: Copy the wheels out of the image
         run: docker run --rm -v $(pwd)/dist:/tmp shazamio_core sh -c "cp -R /opt/dist/* /tmp/"
-
-      - name: List the wheels that were copied
-        run: ls -la dist
 
       - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,9 @@ include = [
     # The generator of the notices above, and what the shipped `justfile` reads in
     #  `licenses-check`: without it that recipe and `ci` fail on a missing file.
     "/licenses/**",
+    # What `dist-check` runs, for the same reason as `licenses/` above: the shipped
+    #  `justfile` names the script, and the recipe fails on a missing file without it.
+    "/scripts/**",
 ]
 
 [lib]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,10 @@ include = [
     "/licenses/**",
     # What `dist-check` runs, for the same reason as `licenses/` above: the shipped
     #  `justfile` names the script, and the recipe fails on a missing file without it.
-    "/scripts/**",
+    #  Named rather than globbed, unlike `licenses/`: that directory ships whole
+    #  because `cargo about` needs both its files, while `scripts/` is a bucket a
+    #  scratch helper can land in, and `include` would ship it over `.gitignore`.
+    "/scripts/check_dist.py",
 ]
 
 [lib]

--- a/justfile
+++ b/justfile
@@ -120,6 +120,16 @@ licenses-check:
     just licenses "$generated"
     diff -u {{ notices }} "$generated"
 
+# Nothing else opens a release archive, and every way of getting one wrong is
+#  silent: a wheel without the stub type-checks as `Any`, and a source archive
+#  without `licenses/` fails nothing until somebody runs `licenses-check` inside
+#  it. What ships is decided by `include` in `Cargo.toml`, `license-files` in
+#  `pyproject.toml` and `maturin` itself, none of which can see the others.
+#  `--no-project`: the checker imports nothing outside the standard library.
+[doc("Check the built artifacts in a directory carry what they should")]
+dist-check directory="dist":
+    uv run --no-project python scripts/check_dist.py {{ directory }}
+
 # --- CI ---
 
 [doc("Everything CI gates on; the first run downloads the MSRV toolchain")]

--- a/scripts/check_dist.py
+++ b/scripts/check_dist.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Check that a built wheel or source distribution carries what it should."""
+
+import sys
+import tarfile
+import zipfile
+from dataclasses import dataclass
+from fnmatch import fnmatch
+from pathlib import Path
+from typing import Final
+
+
+@dataclass(frozen=True, slots=True)
+class Rules:
+    """What an artifact of one kind must carry, must not carry, and reads metadata from."""
+
+    required: tuple[tuple[str, ...], ...]
+    forbidden: tuple[str, ...]
+    metadata_entry: str
+
+
+@dataclass(frozen=True, slots=True)
+class Artifact:
+    entries: tuple[str, ...]
+    metadata: str
+
+
+# The three fields the two manifests argue over: `Summary` reaches the metadata only
+#  through `dynamic`, `License-Expression` only from a literal `license`, and
+#  `Requires-Python` is what `pip` reads before it installs anything. Each is empty
+#  rather than wrong when the wiring breaks, which no build reports.
+_REQUIRED_METADATA: Final[tuple[str, ...]] = ("Summary", "License-Expression", "Requires-Python")
+
+# A group is one requirement: at least one of its patterns has to match. The
+#  extension is a group because its suffix is `.pyd` on Windows and `.so` elsewhere,
+#  and the PyPy wheel names it after the interpreter rather than `abi3`. Nothing is
+#  forbidden: `[tool.maturin]` names no `include`, so what a wheel carries is
+#  `maturin`'s decision alone.
+_WHEEL: Final[Rules] = Rules(
+    required=(
+        ("shazamio_core/__init__.py",),
+        ("shazamio_core/py.typed",),
+        ("shazamio_core/shazamio_core.pyi",),
+        ("shazamio_core/*.so", "shazamio_core/*.pyd"),
+        ("*.dist-info/licenses/LICENSE",),
+        ("*.dist-info/licenses/THIRD-PARTY-NOTICES.md",),
+    ),
+    forbidden=(),
+    metadata_entry="*.dist-info/METADATA",
+)
+
+# Only what can go missing with nothing saying so. `Cargo.toml`, `Cargo.lock`,
+#  `pyproject.toml` and `PKG-INFO` are added by the build whatever `include` says,
+#  and a missing `README.md` fails it outright, so none of them can reach here.
+#  The forbidden half makes a widened pattern in `include` fail rather than ship: a
+#  built extension is named because `include` overrides `.gitignore`.
+_SDIST: Final[Rules] = Rules(
+    required=(
+        ("LICENSE",),
+        ("THIRD-PARTY-NOTICES.md",),
+        ("justfile",),
+        ("licenses/about.toml",),
+        ("licenses/notices.hbs",),
+        ("scripts/check_dist.py",),
+        ("shazamio_core/__init__.py",),
+        ("shazamio_core/py.typed",),
+        ("shazamio_core/shazamio_core.pyi",),
+        ("tests/*.py",),
+    ),
+    forbidden=(
+        ".github/*",
+        ".gitignore",
+        ".pre-commit-config.yaml",
+        "docker/*",
+        "shazamio_core/*.pyd",
+        "shazamio_core/*.so",
+        "uv.lock",
+    ),
+    metadata_entry="PKG-INFO",
+)
+
+
+def _matches(entries: tuple[str, ...], *, pattern: str) -> list[str]:
+    return [entry for entry in entries if fnmatch(entry, pattern)]
+
+
+def _read_wheel(path: Path) -> Artifact:
+    with zipfile.ZipFile(path) as archive:
+        entries = tuple(sorted(archive.namelist()))
+        found = _matches(entries, pattern=_WHEEL.metadata_entry)
+        metadata = archive.read(found[0]).decode() if len(found) == 1 else ""
+
+    return Artifact(
+        entries=entries,
+        metadata=metadata,
+    )
+
+
+def _read_sdist(path: Path) -> Artifact:
+    with tarfile.open(path) as archive:
+        members = archive.getnames()
+
+        # Every path carries a `<name>-<version>/` prefix that says nothing about what
+        #  was shipped, so the rules above are written without it.
+        prefix = members[0].split("/", 1)[0]
+        entries = tuple(sorted(member.split("/", 1)[1] for member in members if "/" in member))
+
+        found = _matches(entries, pattern=_SDIST.metadata_entry)
+        extracted = archive.extractfile(f"{prefix}/{found[0]}") if len(found) == 1 else None
+        metadata = extracted.read().decode() if extracted is not None else ""
+
+    return Artifact(
+        entries=entries,
+        metadata=metadata,
+    )
+
+
+def _declared_fields(metadata: str) -> set[str]:
+    fields: set[str] = set()
+
+    # Only the headers: the body after the first blank line is the long description,
+    #  and a line of it can look exactly like one.
+    for line in metadata.splitlines():
+        if not line:
+            break
+
+        name, separator, value = line.partition(":")
+
+        if separator and value.strip():
+            fields.add(name)
+
+    return fields
+
+
+def _problems(artifact: Artifact, *, rules: Rules) -> list[str]:
+    found: list[str] = []
+
+    for group in rules.required:
+        if not any(_matches(artifact.entries, pattern=pattern) for pattern in group):
+            found.append(f"missing {' or '.join(group)}")
+
+    for pattern in rules.forbidden:
+        for entry in _matches(artifact.entries, pattern=pattern):
+            matched = "" if entry == pattern else f", matched by `{pattern}`"
+            found.append(f"ships {entry}{matched}")
+
+    declared = _declared_fields(artifact.metadata)
+
+    for field in _REQUIRED_METADATA:
+        if field not in declared:
+            found.append(f"declares no `{field}` in {rules.metadata_entry}")
+
+    return found
+
+
+def _check(path: Path, *, artifact: Artifact, rules: Rules) -> bool:
+    """Report what is wrong with one artifact, and answer whether anything was."""
+    found = _problems(artifact, rules=rules)
+
+    for problem in found:
+        print(f"{path.name}: {problem}", file=sys.stderr)
+
+    if not found:
+        print(f"{path.name}: {len(artifact.entries)} entries, all checks passed")
+
+    return bool(found)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: {sys.argv[0]} <directory of built artifacts>", file=sys.stderr)
+        return 2
+
+    directory = Path(sys.argv[1])
+    wheels = sorted(directory.glob("*.whl"))
+    sdists = sorted(directory.glob("*.tar.gz"))
+
+    if not wheels and not sdists:
+        print(f"{directory}: no wheel and no source distribution to check", file=sys.stderr)
+        return 1
+
+    failed: bool = False
+
+    for path in wheels:
+        failed |= _check(
+            path,
+            artifact=_read_wheel(path),
+            rules=_WHEEL,
+        )
+
+    for path in sdists:
+        failed |= _check(
+            path,
+            artifact=_read_sdist(path),
+            rules=_SDIST,
+        )
+
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Nothing in this workflow has ever opened a release archive. `sdist` builds one and uploads it, `Test` compiles the extension from the working tree rather than from the archive, and `linux` installs the wheel but only on Linux. The source distribution reaches `maturin upload` unopened by anything.

This adds two checks, narrows what the archive is allowed to carry, and tidies the workflow that runs them. Both checks sit in the jobs that produce the artifacts, so `release` cannot publish past a failure: it already waits on all of them, and on a tag the path filter step is skipped, which makes every filter output read as `true`.

## What the artifacts carry

`scripts/check_dist.py` reads a wheel with `zipfile` and an archive with `tarfile`, then checks a required list, a forbidden list and the metadata fields. It imports nothing outside the standard library. `just dist-check` runs it, and `windows`, `macos`, `linux` and `sdist` call it before their upload step.

The required list holds only what can go missing with nothing else saying so. `Cargo.toml`, `Cargo.lock`, `pyproject.toml` and `PKG-INFO` are added by the build whatever `include` says, and a missing `README.md` fails it outright, so none of those are listed. The forbidden list is what makes a widened pattern in `include` fail instead of ship, and it names the built extension because `include` overrides `.gitignore`.

Breaking one of each class on purpose:

```
…whl:    missing shazamio_core/py.typed
…whl:    missing *.dist-info/licenses/THIRD-PARTY-NOTICES.md
…whl:    declares no `License-Expression` in *.dist-info/METADATA
…tar.gz: missing licenses/about.toml
…tar.gz: ships uv.lock
exit: 1
```

On the artifacts as they stand:

```
…whl:    10 entries, all checks passed
…tar.gz: 43 entries, all checks passed
```

## That the archive is installable

A list of names proves a name is present. It does not prove the archive builds, which is what somebody gets wherever no wheel exists for their platform. `sdist` now unpacks it and runs the suite out of it:

```yaml
- name: Check a wheel builds out of the archive and its suite passes
  run: |
    tar -xzf dist/*.tar.gz -C "$RUNNER_TEMP"
    cd "$RUNNER_TEMP"/shazamio_core-*

    just install-test
    just test-python
```

79 seconds on this run, inside a job that finishes in 114 while `macos` takes 169, so it is nowhere near the critical path. It also proves the archive resolves without `uv.lock`, which the archive deliberately omits.

`Swatinem/rust-cache` caches the registry only and writes only from `master`. Both come from the 10 GB cache limit this repository has gone over once: a release `target/` is the largest thing that could go back in there, and a cache exported from a pull request is scoped to `refs/pull/N/merge`, which neither `master` nor another pull request can read. The `cache-to` line of the `linux` job argues the same point.

## What the archive is allowed to carry

The shipped `justfile` names the checker, so the archive has to carry it or `just dist-check` fails inside a source build on a missing file. The obvious entry for that is `/scripts/**`, and it is wrong: `include` is a whitelist that overrides `.gitignore`, so a scratch file left in that directory is published. With an untracked `scripts/scratch_probe.py` on disk and `/scripts/**` in `include`:

```
$ tar -tzf dist/*.tar.gz | grep scripts/
shazamio_core-1.2.0/scripts/check_dist.py
shazamio_core-1.2.0/scripts/scratch_probe.py
```

Naming the one file instead, same untracked file still on disk:

```
$ tar -tzf dist/*.tar.gz | grep scripts/
shazamio_core-1.2.0/scripts/check_dist.py
```

`licenses/**` stays globbed because `cargo about` needs both files in that directory and neither is optional.

The path filter keeps its glob, and the comment beside it now says why the two disagree on purpose: `include` decides what is published, so an entry too wide there ships something, while the filter only decides what re-runs, so an entry too narrow there skips a job and leaves a green history behind.

## The workflow itself

`windows` was indented one space shallower than every other job, a bare `#` sat between two of them, blank lines between steps were present in some jobs and absent in others, and four jobs had no `name:` while the other seven did. Naming them also fixes what the check list reads as, since an unnamed matrix job prints every matrix value:

```
sdist                                             ->  Source distribution
windows (x64)                                     ->  Wheel (windows x64)
macos (macos-latest, aarch64-apple-darwin)        ->  Wheel (aarch64-apple-darwin)
linux (manylinux-arm, aarch64, ubuntu-24.04-arm)  ->  Wheel (manylinux-arm)
```

Two steps in `linux` that only ran `ls` on a directory are gone. Nothing else changed: loading the file before and after with `yaml.safe_load` and comparing the flattened structures leaves those names, the reordered `needs` list and one comment moved into a `run:` script, which is everything the parser can see.

## The wiring

| File | Change |
| --- | --- |
| `scripts/check_dist.py` | New. The checker itself. |
| `justfile` | The `dist-check` recipe. |
| `.github/workflows/ci.yaml` | The call in four jobs, the build out of the archive, and the formatting above. |
| `.github/path-filters.yaml` | `shazamio_core/**` and `scripts/**` join `dist`. Without them, deleting `py.typed` starts no distribution job at all, so the check would not run on the change that breaks it. |
| `Cargo.toml` | `/scripts/check_dist.py` joins `include`, so the `justfile` that ships in the archive does not name a file the archive lacks. |

## Why

What ships is decided in three places that cannot see each other, and every way of getting it wrong is quiet. A wheel without the type stub checks as `Any`. An archive without `licenses/` fails nothing until somebody runs `licenses-check` inside it. A metadata field comes out empty rather than wrong when the manifest wiring breaks.

## How to test

```sh
maturin build --out target/dist
maturin sdist --out target/dist
just dist-check target/dist
```

Then unpack the archive somewhere outside the checkout and run `just install-test && just test-python` inside it.
